### PR TITLE
Pull docker image from pyrsia node

### DIFF
--- a/pyrsia-node/Cargo.lock
+++ b/pyrsia-node/Cargo.lock
@@ -587,6 +587,7 @@ name = "pyrsia-node"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "log",
  "pretty_env_logger",
  "tokio",
  "warp",

--- a/pyrsia-node/Cargo.toml
+++ b/pyrsia-node/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 clap = "2.33.0"
+log = "0.4.14"
 pretty_env_logger = "0.4.0"
 tokio = { version = "1", features = [ "macros", "rt-multi-thread" ] }
 warp = "0.3.1"


### PR DESCRIPTION
This PR lets the Pyrsia Node act as a docker registry, implementing the [pull workflow](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pull), described in the OCI Distribution Specification.

This allows one to pull a docker image from the pyrsia node with i.e. `docker pull localhost:7878/alpine` and thereby fixes #11.

To test the PR, you can follow these steps:

* clone https://github.com/distribution/distribution
* build it with `make` (you need to have `go` installed, [docs are here](https://golang.org/doc/install))
* add a file named `config.yml` with the following content:
```
version: "0.1"
log:
  level: debug
http:
  secret: abcd
  addr: 127.0.0.1:5000
storage:
  filesystem:
   rootdirectory: /tmp/registry
```
* start a local registry with: `./bin/registry serve config.yml`
* open a new terminal and start a pyrsia node with: `RUST_LOG=pyrsia cargo run -q`
* open a third terminal to work with docker pull
     * pull the alpine docker image: `docker pull alpine`
     * tag it to prepare for local push: `docker tag alpine localhost:5000/alpine`
     * push to the local go registry: `docker push localhost:5000/alpine`
     * remove the image from docker: `docker rmi alpine`
     * remove the tagged image: `docker rmi localhost:5000/alpine`
     * finally, pull the image again from pyrsia node: `docker pull localhost:7878/alpine`
     * (optional) test that the image works: `docker run -it localhost:7878/alpine /bin/sh`

There's another small change to be able to specify the port as a CLI argument. The default port is 7878.