### PR TITLE
Basic CI Outline

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,6 +27,5 @@ jobs:
           target/
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-    - run: cargo install --verbose --locked
-    - run: cargo build --verbose
+    - run: cargo build --verbose --locked
     - run: cargo test --verbose


### PR DESCRIPTION
Simply builds against a the `cargo.lock` and run the tests. Uses caching for the dependencies.