### PR TITLE
Add a nice message when `rustfmt` fails

### DIFF
--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -17,6 +17,8 @@ jobs:
       - uses: actions/checkout@v1
       - run: rustup component add rustfmt
       - run: cargo fmt -- --check # Prints diff in the action logs
+      - if: failure()
+        run: echo "::error ::You need to run `rustfmt` loaclly, commit the changes, and push"
 
   clippy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
As per our conversation, I've added a failed message to help.