### PR TITLE
Use `pull_request_target` to assign author

### DIFF
--- a/.github/workflows/auto-assign-author.yml
+++ b/.github/workflows/auto-assign-author.yml
@@ -1,7 +1,7 @@
 name: Auto Author Assign
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, ready_for_review]
 
 permissions:


### PR DESCRIPTION
This was caught by a search and replace.

It's "safe" to use it here since we do no checkout any code but we need write permissions to complete the action