### PR TITLE
Cleanup files after documentstore tests are executed.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -865,6 +865,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "filename"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e4df03effebdf9cfa31a663f569fd96cc7e206184b0d4dcd388dc490f7ebe8"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2660,6 +2670,7 @@ dependencies = [
  "ctor",
  "easy-hasher",
  "env_logger 0.9.0",
+ "filename",
  "futures",
  "hex",
  "hyper",
@@ -2675,6 +2686,7 @@ dependencies = [
  "stringreader",
  "strum",
  "strum_macros",
+ "tempfile",
  "tokio",
  "unqlite",
  "uuid",

--- a/pyrsia_node/Cargo.toml
+++ b/pyrsia_node/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 anyhow = "1.0.45"
 blake3 = "1.2.0"
 env_logger = "0.9.0"
+filename = "0.1.1"
 futures = "0.3.17"
 bytes = "1.1.0"
 clap = "2.33.0"
@@ -28,6 +29,7 @@ sha2 = { version = "0.9.8" }
 stringreader = "0.1.1"
 strum = "0.22.0"
 strum_macros = "0.22.0"
+tempfile = "3.2.0"
 tokio = { version = "1", features = [ "macros", "rt-multi-thread", "io-std" ] }
 #libp2p = "0.40.0"
 libp2p = {git = "https://github.com/decentnetwork/rust-libp2p.git", branch = "fix-compiling-v0.40", features=["tcp-tokio"]}

--- a/pyrsia_node/src/document_store/document_store.rs
+++ b/pyrsia_node/src/document_store/document_store.rs
@@ -191,8 +191,11 @@ mod tests {
     // Create a database with a name and an empty index list
     #[test]
     fn test_create_db() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let path = tmp_dir.path().join("test_create_db");
+        let name = path.to_str().unwrap();
         let mut doc_store = DocumentStore::new();
-        let name: &str = "test_create_db";
+        // let name: &str = "test_create_db";
         let idx = vec![];
         doc_store.create_db(name, idx);
     }
@@ -200,8 +203,10 @@ mod tests {
     // Create a database with a name and an index list with 2 elements
     #[test]
     fn test_create_db_with_index() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let path = tmp_dir.path().join("test_create_db_with_index");
+        let name = path.to_str().unwrap();
         let mut doc_store = DocumentStore::new();
-        let name: &str = "test_create_db_with_index";
         let n1 = "mostSignificantField".to_string();
         let t1 = "string".to_string();
         let n2 = "leastSignificantField".to_string();
@@ -214,8 +219,10 @@ mod tests {
 
     #[test]
     fn test_store() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let path = tmp_dir.path().join("test_store");
+        let name = path.to_str().unwrap();
         let mut doc_store = DocumentStore::new();
-        let name: &str = "test_store";
         let n1 = "mostSignificantField".to_string();
         let t1 = "string".to_string();
         let n2 = "leastSignificantField".to_string();
@@ -230,8 +237,10 @@ mod tests {
 
     #[test]
     fn test_fetch() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let path = tmp_dir.path().join("test_fetch");
+        let name = path.to_str().unwrap();
         let mut doc_store = DocumentStore::new();
-        let name: &str = "test_fetch";
         let n1 = "mostSignificantField".to_string();
         let t1 = "string".to_string();
         let n2 = "leastSignificantField".to_string();
@@ -251,8 +260,10 @@ mod tests {
 
     #[test]
     fn test_fetch_not_found() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let path = tmp_dir.path().join("test_not_found");
+        let name = path.to_str().unwrap();
         let mut doc_store = DocumentStore::new();
-        let name: &str = "test_fetch_not_found";
         let n1 = "mostSignificantField".to_string();
         let t1 = "string".to_string();
         let n2 = "leastSignificantField".to_string();

--- a/pyrsia_node/src/document_store/document_store.rs
+++ b/pyrsia_node/src/document_store/document_store.rs
@@ -195,7 +195,6 @@ mod tests {
         let path = tmp_dir.path().join("test_create_db");
         let name = path.to_str().unwrap();
         let mut doc_store = DocumentStore::new();
-        // let name: &str = "test_create_db";
         let idx = vec![];
         doc_store.create_db(name, idx);
     }


### PR DESCRIPTION
This introduces a few more dependencies: filename and tempfile.
fix for #78