### PR TITLE
Automatically label and notify when merge conflicts a rise

### DIFF
--- a/.github/workflows/label-conflicts.yml
+++ b/.github/workflows/label-conflicts.yml
@@ -1,0 +1,17 @@
+name: Auto Label Conflicts
+on:
+  push:
+    branches: [main]
+  pull_request_target:
+    branches: [main]
+
+jobs:
+  auto-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: prince-chrismc/label-merge-conflicts-action@v1
+        with:
+          conflict_label_name: "has conflict"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          detect_merge_changes: false # or true to handle as conflicts
+          conflict_comment: ":wave: Hi, @${author},\n\nI detected conflicts against the base branch. You'll want sync :arrows_counterclockwise: your branch with upstream!"

--- a/.github/workflows/label-conflicts.yml
+++ b/.github/workflows/label-conflicts.yml
@@ -14,4 +14,4 @@ jobs:
           conflict_label_name: "has conflict"
           github_token: ${{ secrets.GITHUB_TOKEN }}
           detect_merge_changes: false # or true to handle as conflicts
-          conflict_comment: ":wave: Hi, @${author},\n\nI detected conflicts against the base branch. You'll want sync :arrows_counterclockwise: your branch with upstream!"
+          conflict_comment: ":wave: Hi, @${author},\n\nI detected conflicts against the base branch. You'll want to sync :arrows_counterclockwise: your branch with upstream!"


### PR DESCRIPTION
- [x] Create a new label

***

After reading https://doc.rust-lang.org/cargo/reference/workspaces.html

> A workspace is a collection of one or more packages that share common dependency resolution (with a shared Cargo.lock)

I am not sure how we can improve the project to avoid this pain point. In the mean time I am proposing this to help us navigate the continuous annoyance.