### PR TITLE
Project board automation

### DIFF
--- a/.github/workflows/board-automation.yml
+++ b/.github/workflows/board-automation.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'project_card' && github.event.action == 'moved' &&
-      github.event.project_card.column_id == '16583787'
+      github.event.project_card.column_id == '16583791' # Blocked https://github.com/orgs/pyrsia/projects/2#column-16583791
     steps:
       - uses: andymckay/labeler@1.0.4
         with:

--- a/.github/workflows/board-automation.yml
+++ b/.github/workflows/board-automation.yml
@@ -1,0 +1,16 @@
+name: Project Board Automation - Pyrsia Develop
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  label-blocked:
+    runs-on: ubuntu-latest
+    if: github.event.action == 'labeled' && github.event.label.name == 'blocked'
+    steps:
+      - uses: alex-page/github-project-automation-plus@v0.8.1
+        with:
+          project: Pyrsia Develop
+          column: Blocked
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/board-automation.yml
+++ b/.github/workflows/board-automation.yml
@@ -2,15 +2,42 @@ name: Project Board Automation - Pyrsia Develop
 
 on:
   issues:
-    types: [labeled]
+    types: [created, reopend, labeled]
+  project_card:
+    types: [moved]
 
 jobs:
+  triage-new-issues:
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'issues' &&
+      github.event.action == 'created' && github.event.action == 'reopend'
+    steps:
+      - uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: triage
+      - uses: alex-page/github-project-automation-plus@v0.8.1
+        with:
+          project: Pyrsia Develop
+          column: Backlog for them Demo
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+    
   label-blocked:
     runs-on: ubuntu-latest
-    if: github.event.action == 'labeled' && github.event.label.name == 'blocked'
+    if: github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'blocked'
     steps:
       - uses: alex-page/github-project-automation-plus@v0.8.1
         with:
           project: Pyrsia Develop
           column: Blocked
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+  
+  move-to-blocked:
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'project_card' && github.event.action == 'moved' &&
+      github.event.project_card.column_id == '16583787'
+    steps:
+      - uses: andymckay/labeler@1.0.4
+        with:
+          add-labels: blocked


### PR DESCRIPTION
This adds three new jobs

1. Triage label is added to new issues (and they should be moved to the backlog)
2. Adding the "blocked" label will move it to the column
3. Move to the "blocked" column will add the correct label

***

These only work when they are merged so I need to push this before I can test (RIP me)