### PR TITLE
Disable complaints about generated new methods with too many arguments.

### DIFF
--- a/pyrsia_node/pyrsia_client_lib/signed_struct/src/lib.rs
+++ b/pyrsia_node/pyrsia_client_lib/signed_struct/src/lib.rs
@@ -169,6 +169,7 @@ pub fn signed_struct_derive(input: TokenStream) -> TokenStream {
                                 }
 
                                 impl #lifetime #struct_ident #lifetime {
+                                    #[allow(clippy::too_many_arguments)]
                                     pub fn new(#( #field_ident_vec : #type_vec),*) -> #struct_ident {
                                         #struct_ident{ #(#field_ident_vec),* , #json_field_name: None }
                                     }


### PR DESCRIPTION
Clippy is complaining that the mechanically generated `new` methods generated by the `#[signed_struct]` macro have too many parameters if the struct in question has more than 7 fields.

I have modified the macro to generate a 
#[allow(clippy::too_many_arguments)]
before the `new` methods to stop the complaining