### PR TITLE
Docker manifest (schemaVersion 1) to package version

### DIFF
--- a/pyrsia_node/src/docker/v2/handlers/manifests.rs
+++ b/pyrsia_node/src/docker/v2/handlers/manifests.rs
@@ -265,8 +265,8 @@ fn package_version_from_manifest_json(
     docker_reference: &str,
 ) -> Result<PackageVersion, anyhow::Error> {
     let result = match manifest_schema_version(json_object, json_string)? {
-        1 => package_version_from_schema1(&json_object),
-        2 => package_version_from_schema2(&json_object, json_string, docker_name, docker_reference),
+        1 => package_version_from_schema1(json_object),
+        2 => package_version_from_schema2(json_object, json_string, docker_name, docker_reference),
         n => Err(anyhow!("Unsupported manifest schema version {}", n)),
     };
     if result.is_err() {
@@ -275,7 +275,7 @@ fn package_version_from_manifest_json(
     result
 }
 
-const FS_LAYERS: &'static str = "fsLayers";
+const FS_LAYERS: &str = "fsLayers";
 
 fn package_version_from_schema1(
     json_object: &Map<String, Value>,

--- a/pyrsia_node/src/docker/v2/handlers/manifests.rs
+++ b/pyrsia_node/src/docker/v2/handlers/manifests.rs
@@ -290,9 +290,9 @@ fn package_version_from_schema1(
             return Err(anyhow!("Only sha256 digests are supported: {}", hex_digest));
         }
         let digest = hex::decode(&hex_digest["sha256:".len()..])?;
-        artifacts.push( Artifact { hash: digest, })
+        artifacts.push( Artifact::new(digest, HashAlgorithm::SHA256, None, None, None, None, None, Map::new(), None))
     }
-    Ok(PackageVersion {})
+    Ok(PackageVersion::new())
 }
 
 fn package_version_from_schema2(

--- a/pyrsia_node/src/docker/v2/handlers/manifests.rs
+++ b/pyrsia_node/src/docker/v2/handlers/manifests.rs
@@ -525,7 +525,10 @@ mod tests {
         assert!(package_version.description().is_none());
         assert_eq!(4, package_version.artifacts().len());
         assert_eq!(32, package_version.artifacts()[0].hash().len());
-        assert_eq!(HashAlgorithm::SHA256, *package_version.artifacts()[0].algorithm());
+        assert_eq!(
+            HashAlgorithm::SHA256,
+            *package_version.artifacts()[0].algorithm()
+        );
         assert!(package_version.artifacts()[0].name().is_none());
         assert!(package_version.artifacts()[0].creation_time().is_none());
         assert!(package_version.artifacts()[0].url().is_none());

--- a/pyrsia_node/src/docker/v2/handlers/manifests.rs
+++ b/pyrsia_node/src/docker/v2/handlers/manifests.rs
@@ -18,9 +18,13 @@ use super::{RegistryError, RegistryErrorCode};
 
 use crate::artifact_manager;
 use crate::artifact_manager::HashAlgorithm;
+use crate::node_manager::model::artifact::Artifact;
+use crate::node_manager::model::package_version::PackageVersion;
+use anyhow::{anyhow, Context, Error};
 use bytes::Bytes;
 use easy_hasher::easy_hasher::{file_hash, raw_sha256, raw_sha512, Hash};
-use log::{debug, info, warn};
+use log::{debug, error, info, warn};
+use serde_json::{Map, Value};
 use std::fs;
 use uuid::Uuid;
 use warp::http::StatusCode;
@@ -79,11 +83,28 @@ pub async fn handle_put_manifest(
     let id = Uuid::new_v4();
 
     match store_manifest_in_artifact_manager(&bytes) {
-        Ok(artifact_hash) => info!(
-            "Stored manifest with {} hash {}",
-            artifact_hash.0,
-            hex::encode(artifact_hash.1)
-        ),
+        Ok(artifact_hash) => {
+            info!(
+                "Stored manifest with {} hash {}",
+                artifact_hash.0,
+                hex::encode(artifact_hash.1)
+            );
+            let package_version =
+                match package_version_from_manifest_bytes(&bytes, &name, &reference) {
+                    Ok(pv) => pv,
+                    Err(error) => {
+                        let err_string = error.to_string();
+                        error!("{}", err_string);
+                        return Err(warp::reject::custom(RegistryError {
+                            code: RegistryErrorCode::Unknown(err_string),
+                        }));
+                    }
+                };
+            info!(
+                "Created PackageVersion from manifest: {:?}",
+                package_version
+            );
+        }
         Err(error) => warn!("Error storing manifest in artifact_manager {}", error),
     };
 
@@ -212,6 +233,108 @@ fn store_manifest_in_artifact_manager(bytes: &Bytes) -> anyhow::Result<(HashAlgo
     Ok((HashAlgorithm::SHA512, sha512))
 }
 
+fn package_version_from_manifest_bytes(
+    bytes: &Bytes,
+    docker_name: &str,
+    docker_reference: &str,
+) -> Result<PackageVersion, anyhow::Error> {
+    let json_string = String::from_utf8(bytes.to_vec())?;
+    match serde_json::from_str::<Value>(&json_string) {
+        Ok(Value::Object(json_object)) => package_version_from_manifest_json(
+            &json_object,
+            &json_string,
+            docker_name,
+            docker_reference,
+        ),
+        Ok(_) => invalid_manifest(&json_string),
+        Err(_) => Err(anyhow!(
+            "Error parsing docker manifest JSON: {}",
+            json_string
+        )),
+    }
+}
+
+fn package_version_from_manifest_json(
+    json_object: &Map<String, Value>,
+    json_string: &str,
+    docker_name: &str,
+    docker_reference: &str,
+) -> Result<PackageVersion, anyhow::Error> {
+    match manifest_schema_version(json_object, json_string)? {
+        1 => package_version_from_schema1(&json_object),
+        2 => package_version_from_schema2(&json_object, json_string, docker_name, docker_reference),
+        n => Err(anyhow!("Unsupported manifest schema version {}", n)),
+    }
+}
+
+fn package_version_from_schema1(
+    json_object: &Map<String, Value>,
+) -> Result<PackageVersion, anyhow::Error> {
+    let manifest_name = value_of(json_object, "name", serde_json::value::Value::as_str)?;
+    let manifest_tag = value_of(json_object, "tag", serde_json::value::Value::as_str)?;
+    let fslayers = json_object
+        .get("fslayers")
+        .context("missing fslayers field")?
+        .as_array()
+        .context("invalid fslayers")?;
+    let mut artifacts: Vec<Artifact> = Vec::new();
+    for fslayer in fslayers {
+        let hex_digest = fslayer
+            .as_object()
+            .context("invalid fslayer")?
+            .get("blobSum")
+            .context("missing blobSum")?
+            .as_str()
+            .context("invalid blogSum")?;
+        if !hex_digest.starts_with("sha256:") {
+            return Err(anyhow!("Only sha256 digests are supported: {}", hex_digest));
+        }
+        let digest = hex::decode(&hex_digest["sha256:".len()..])?;
+        artifacts.push( Artifact { hash: digest, })
+    }
+    Ok(PackageVersion {})
+}
+
+fn package_version_from_schema2(
+    json_object: &Map<String, Value>,
+    json_string: &str,
+    docker_name: &str,
+    docker_reference: &str,
+) -> Result<PackageVersion, anyhow::Error> {
+}
+
+fn manifest_schema_version(
+    json_object: &Map<String, Value>,
+    json_string: &str,
+) -> Result<u64, anyhow::Error> {
+    match json_object.get("schemaVersion") {
+        Some(Value::Number(n)) => match n.as_u64() {
+            Some(version) => Ok(version),
+            None => invalid_manifest(json_string),
+        },
+        Some(Value::String(s)) => s
+            .as_str()
+            .parse::<u64>()
+            .with_context(|| !format!("Invalid schemaVersion value: {}", s)),
+        _ => invalid_manifest(json_string),
+    }
+}
+
+fn value_of<T>(
+    json_object: &Map<String, Value>,
+    field_name: &str,
+    f: fn(&Value) -> Option<T>,
+) -> Result<T, anyhow::Error> {
+    f(json_object
+        .get(field_name)
+        .with_context(|| format!("missing {} field", field_name))?)
+    .with_context(|| format!("invalid {}", field_name))
+}
+
+fn invalid_manifest<T>(json_string: &str) -> Result<T, anyhow::Error> {
+    Err(anyhow!("Invalid JSON manifest: {}", json_string))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -222,7 +345,50 @@ mod tests {
     use serde::de::StdError;
     use std::fs::read_to_string;
 
-    const MANIFEST_JSON: &str = r##"{
+    const MANIFEST_V1_JSON: &str = r##"{
+   "name": "hello-world",
+   "tag": "latest",
+   "architecture": "amd64",
+   "fsLayers": [
+      {
+         "blobSum": "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
+      },
+      {
+         "blobSum": "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
+      },
+      {
+         "blobSum": "sha256:cc8567d70002e957612902a8e985ea129d831ebe04057d88fb644857caa45d11"
+      },
+      {
+         "blobSum": "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
+      }
+   ],
+   "history": [
+      {
+         "v1Compatibility": "{\"id\":\"e45a5af57b00862e5ef5782a9925979a02ba2b12dff832fd0991335f4a11e5c5\",\"parent\":\"31cbccb51277105ba3ae35ce33c22b69c9e3f1002e76e4c736a2e8ebff9d7b5d\",\"created\":\"2014-12-31T22:57:59.178729048Z\",\"container\":\"27b45f8fb11795b52e9605b686159729b0d9ca92f76d40fb4f05a62e19c46b4f\",\"container_config\":{\"Hostname\":\"8ce6509d66e2\",\"Domainname\":\"\",\"User\":\"\",\"Memory\":0,\"MemorySwap\":0,\"CpuShares\":0,\"Cpuset\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"PortSpecs\":null,\"ExposedPorts\":null,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"],\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) CMD [/hello]\"],\"Image\":\"31cbccb51277105ba3ae35ce33c22b69c9e3f1002e76e4c736a2e8ebff9d7b5d\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"NetworkDisabled\":false,\"MacAddress\":\"\",\"OnBuild\":[],\"SecurityOpt\":null,\"Labels\":null},\"docker_version\":\"1.4.1\",\"config\":{\"Hostname\":\"8ce6509d66e2\",\"Domainname\":\"\",\"User\":\"\",\"Memory\":0,\"MemorySwap\":0,\"CpuShares\":0,\"Cpuset\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"PortSpecs\":null,\"ExposedPorts\":null,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"],\"Cmd\":[\"/hello\"],\"Image\":\"31cbccb51277105ba3ae35ce33c22b69c9e3f1002e76e4c736a2e8ebff9d7b5d\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"NetworkDisabled\":false,\"MacAddress\":\"\",\"OnBuild\":[],\"SecurityOpt\":null,\"Labels\":null},\"architecture\":\"amd64\",\"os\":\"linux\",\"Size\":0}\n"
+      },
+      {
+         "v1Compatibility": "{\"id\":\"e45a5af57b00862e5ef5782a9925979a02ba2b12dff832fd0991335f4a11e5c5\",\"parent\":\"31cbccb51277105ba3ae35ce33c22b69c9e3f1002e76e4c736a2e8ebff9d7b5d\",\"created\":\"2014-12-31T22:57:59.178729048Z\",\"container\":\"27b45f8fb11795b52e9605b686159729b0d9ca92f76d40fb4f05a62e19c46b4f\",\"container_config\":{\"Hostname\":\"8ce6509d66e2\",\"Domainname\":\"\",\"User\":\"\",\"Memory\":0,\"MemorySwap\":0,\"CpuShares\":0,\"Cpuset\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"PortSpecs\":null,\"ExposedPorts\":null,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"],\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) CMD [/hello]\"],\"Image\":\"31cbccb51277105ba3ae35ce33c22b69c9e3f1002e76e4c736a2e8ebff9d7b5d\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"NetworkDisabled\":false,\"MacAddress\":\"\",\"OnBuild\":[],\"SecurityOpt\":null,\"Labels\":null},\"docker_version\":\"1.4.1\",\"config\":{\"Hostname\":\"8ce6509d66e2\",\"Domainname\":\"\",\"User\":\"\",\"Memory\":0,\"MemorySwap\":0,\"CpuShares\":0,\"Cpuset\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"PortSpecs\":null,\"ExposedPorts\":null,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"],\"Cmd\":[\"/hello\"],\"Image\":\"31cbccb51277105ba3ae35ce33c22b69c9e3f1002e76e4c736a2e8ebff9d7b5d\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"NetworkDisabled\":false,\"MacAddress\":\"\",\"OnBuild\":[],\"SecurityOpt\":null,\"Labels\":null},\"architecture\":\"amd64\",\"os\":\"linux\",\"Size\":0}\n"
+      },
+   ],
+   "schemaVersion": 1,
+   "signatures": [
+      {
+         "header": {
+            "jwk": {
+               "crv": "P-256",
+               "kid": "OD6I:6DRK:JXEJ:KBM4:255X:NSAA:MUSF:E4VM:ZI6W:CUN2:L4Z6:LSF4",
+               "kty": "EC",
+               "x": "3gAwX48IQ5oaYQAYSxor6rYYc_6yjuLCjtQ9LUakg4A",
+               "y": "t72ge6kIA1XOjqjVoEOiPPAURltJFBMGDSQvEGVB010"
+            },
+            "alg": "ES256"
+         },
+         "signature": "XREm0L8WNn27Ga_iE_vRnTxVMhhYY0Zst_FfkKopg6gWSoTOZTuW4rK0fg_IqnKkEKlbD83tD46LKEGi5aIVFg",
+         "protected": "eyJmb3JtYXRMZW5ndGgiOjY2MjgsImZvcm1hdFRhaWwiOiJDbjAiLCJ0aW1lIjoiMjAxNS0wNC0wOFQxODo1Mjo1OVoifQ"
+      }]}"##;
+
+    const MANIFEST_V2_IMAGE_JSON: &str = r##"{
 	"schemaVersion": 2,
 	"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
 	"config": {
@@ -276,7 +442,7 @@ mod tests {
             handle_put_manifest(
                 name.to_string(),
                 reference.to_string(),
-                Bytes::from(MANIFEST_JSON.as_bytes()),
+                Bytes::from(MANIFEST_V1_JSON.as_bytes()),
             )
             .await
         };
@@ -300,7 +466,7 @@ mod tests {
     }
 
     fn check_artifact_manager_side_effects() -> Result<(), Box<dyn StdError>> {
-        let manifest_sha512: Vec<u8> = raw_sha512(MANIFEST_JSON.as_bytes().to_vec()).to_vec();
+        let manifest_sha512: Vec<u8> = raw_sha512(MANIFEST_V1_JSON.as_bytes().to_vec()).to_vec();
         let artifact_hash = artifact_manager::Hash::new(HashAlgorithm::SHA512, &manifest_sha512)?;
         ART_MGR.pull_artifact(&artifact_hash)?;
         Ok(())

--- a/pyrsia_node/src/node_manager/model/artifact.rs
+++ b/pyrsia_node/src/node_manager/model/artifact.rs
@@ -35,11 +35,74 @@ pub struct Artifact {
     /// A URL associated with the artifact.
     url: Option<String>,
     /// The size of the artifact.
-    size: u64,
+    size: Option<u64>,
     /// The mime type of the artifact
     mime_type: Option<String>,
     /// Attributes of an artifact that don't fit into one of this struct's fields can go in here as JSON
     metadata: Map<String, Value>,
     /// The URL of the source of the artifact
     source_url: Option<String>,
+}
+
+impl Artifact {
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        hash: Vec<u8>,
+        algorithm: HashAlgorithm,
+        name: Option<String>,
+        creation_time: Option<String>,
+        url: Option<String>,
+        size: Option<u64>,
+        mime_type: Option<String>,
+        metadata: Map<String, Value>,
+        source_url: Option<String>,
+    ) -> Artifact {
+        Artifact {
+            hash,
+            algorithm,
+            name,
+            creation_time,
+            url,
+            size,
+            mime_type,
+            metadata,
+            source_url,
+        }
+    }
+
+    fn hash(&self) -> &Vec<u8> {
+        &self.hash
+    }
+
+    fn algorithm(&self) -> &HashAlgorithm {
+        &self.algorithm
+    }
+
+    fn name(&self) -> &Option<String> {
+        &self.name
+    }
+
+    fn creation_time(&self) -> &Option<String> {
+        &self.creation_time
+    }
+
+    fn url(&self) -> &Option<String> {
+        &self.url
+    }
+
+    fn size(&self) -> &Option<u64> {
+        &self.size
+    }
+
+    fn mime_type(&self) -> &Option<String> {
+        &self.mime_type
+    }
+
+    fn metadata(&self) -> &Map<String, Value> {
+        &self.metadata
+    }
+
+    fn source_url(&self) -> &Option<String> {
+        &self.source_url
+    }
 }

--- a/pyrsia_node/src/node_manager/model/artifact.rs
+++ b/pyrsia_node/src/node_manager/model/artifact.rs
@@ -46,7 +46,7 @@ pub struct Artifact {
 
 impl Artifact {
     #[allow(clippy::too_many_arguments)]
-    fn new(
+    pub fn new(
         hash: Vec<u8>,
         algorithm: HashAlgorithm,
         name: Option<String>,
@@ -70,39 +70,39 @@ impl Artifact {
         }
     }
 
-    fn hash(&self) -> &Vec<u8> {
+    pub fn hash(&self) -> &Vec<u8> {
         &self.hash
     }
 
-    fn algorithm(&self) -> &HashAlgorithm {
+    pub fn algorithm(&self) -> &HashAlgorithm {
         &self.algorithm
     }
 
-    fn name(&self) -> &Option<String> {
+    pub fn name(&self) -> &Option<String> {
         &self.name
     }
 
-    fn creation_time(&self) -> &Option<String> {
+    pub fn creation_time(&self) -> &Option<String> {
         &self.creation_time
     }
 
-    fn url(&self) -> &Option<String> {
+    pub fn url(&self) -> &Option<String> {
         &self.url
     }
 
-    fn size(&self) -> &Option<u64> {
+    pub fn size(&self) -> &Option<u64> {
         &self.size
     }
 
-    fn mime_type(&self) -> &Option<String> {
+    pub fn mime_type(&self) -> &Option<String> {
         &self.mime_type
     }
 
-    fn metadata(&self) -> &Map<String, Value> {
+    pub fn metadata(&self) -> &Map<String, Value> {
         &self.metadata
     }
 
-    fn source_url(&self) -> &Option<String> {
+    pub fn source_url(&self) -> &Option<String> {
         &self.source_url
     }
 }

--- a/pyrsia_node/src/node_manager/model/package_type.rs
+++ b/pyrsia_node/src/node_manager/model/package_type.rs
@@ -28,7 +28,7 @@ pub struct PackageType {
     description: String,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub enum PackageTypeName {
     Docker,
 }


### PR DESCRIPTION
This is the first installment of extracting a packageVersion metadata record from a docker manifest. 

This produces unsigned metadata. This is temporary. It will be moved outside the node where it can be securely signed.