### PR TITLE
Install openssl using brew

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,11 @@ jobs:
           target/
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
+    - name: Install openssl on macOS
+      if: runner.os == 'macOS'
+      run: |
+        brew install openssl
+    
     - run: cargo build --workspace --verbose --locked
     - run: cargo test --workspace --verbose
 
@@ -135,4 +140,3 @@ jobs:
       with:
         files: target/tarpaulin/pyrsia-coverage.json
         fail_ci_if_error: ${{ github.repository_owner == 'pyrsia' }}
-


### PR DESCRIPTION
Need to use openssl from brew instead of the libreSSL which is the OS library.  Rust expects the openssl functions and not libreSSL ones.  Resolves #221 