### PR TITLE
Dockerize Pyrsia Node

### DIFF
--- a/.github/workflows/build-node-image.yml
+++ b/.github/workflows/build-node-image.yml
@@ -1,0 +1,12 @@
+name: Build Pyrsia Node Docker Image
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: docker buildx bake node

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+# syntax=docker/dockerfile:1.3-labs
+
+FROM rust:1.57-buster AS builder
+ENV CARGO_TARGET_DIR=/target
+WORKDIR /src
+RUN apt-get update && apt-get install -y \
+    clang \
+    libclang-dev
+
+FROM builder AS debug
+COPY . .
+
+FROM builder AS dupdatelock
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/git/db \
+    --mount=type=cache,target=/usr/local/cargo/registry/cache \
+    --mount=type=cache,target=/usr/local/cargo/registry/index \
+    cargo update
+
+FROM scratch AS updatelock
+COPY --from=dupdatelock /src/Cargo.lock .
+
+FROM builder AS dbuild
+RUN mkdir -p /out
+ENV RUST_BACKTRACE=1
+RUN --mount=target=/src \
+    --mount=type=cache,target=/target \
+    --mount=type=cache,target=/usr/local/cargo/git/db \
+    --mount=type=cache,target=/usr/local/cargo/registry/cache \
+    --mount=type=cache,target=/usr/local/cargo/registry/index \
+    cargo build --profile=release --package=pyrsia_node && cp /target/release/pyrsia_node /out/
+
+FROM debian:buster-slim AS node
+ENTRYPOINT ["pyrsia_node"]
+RUN <<EOT bash
+    set -e
+    apt-get update
+    apt-get install -y \
+        libssl1.1
+    rm -rf /var/lib/apt/lists/*
+EOT
+COPY --from=dbuild /out/pyrsia_node /usr/local/bin/

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,15 @@
+group "default" {
+    targets = ["node"]
+}
+
+// Update the Cargo.lock file after making changes to Cargo.toml
+target "updatelock" {
+    target = "updatelock"
+    output = ["./"]
+}
+
+// Build a Docker image for Pyrsia node
+target "node" {
+    target = "node"
+    tags = ["pyrsia/node"]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  pyrsia:
+    image: pyrsia/node
+    build:
+      target: node
+    command: ["-p", "7878"]
+    stdin_open: true
+    ports:
+      - "7878:7878"
+    volumes:
+      - "pyrsia:/tmp"
+
+volumes:
+  pyrsia:

--- a/readme.md
+++ b/readme.md
@@ -33,3 +33,13 @@ There are two components of this project
 ### Setting Up Visual Studio Code Debugger
 
 [How to Debug Rust with Visual Studio Code](https://www.forrestthewoods.com/blog/how-to-debug-rust-with-visual-studio-code/)
+
+### Building and running the Pyrsia Node with Docker
+
+1. Install [Docker](https://www.docker.com/get-started)
+2. Run `docker compose up`
+    * macOS and Windows: Compose is included in Docker Desktop
+    * Linux: [Downloaded Compose](https://github.com/docker/compose#linux)
+
+The Pyrsia node will then be running on localhost:7878 both on the host and 
+inside the VM, available to Docker Engine, in the case of Docker Desktop.


### PR DESCRIPTION
Closes: #224 

* Adds Dockerfile
* Adds docker-compose.yml for easy build and deploy
* Adds docker-bake.hcl which is useful for development
* Adds get started guide to README
* Adds simple CI to check that the image build works

To build and run the Pyrsia Node locally, just run `docker compose up` if you have Docker Desktop installed.

An example of what can be done is updating the `Cargo.lock` after a `Cargo.toml` change:
```console
docker buildx bake updatelock
```

**Note:** I'm not a rust developer so how I'm handling caching should be checked.