### PR TITLE
Use cargo-deb to install synapse and pyrsia under systemd

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,124 +30,120 @@ jobs:
       if: runner.os == 'macOS'
       run: |
         brew install openssl
+
+    # Install cargo deb and strip
+    - name: Install cargo-deb cargo-strip
+      if: runner.os == 'Linux'
+      uses: actions-rs/cargo@v1.0.1
+      with: 
+        command: install
+        args: cargo-deb cargo-strip --force
+
+    # Need to add build number to version number
+    - name: Iterate Build Version Number
+      run: |
+        sed -i.bak "/^version = \"0.1.0\"/s/\"\$/+${{ github.run_number }}\"/" Cargo.toml
+
+    - name: Build Release Binaries
+      run: |
+        cargo build --workspace --verbose  --release
     
-    - run: cargo build --workspace --verbose --locked --release
-    - run: cargo test --workspace --verbose
+    - name: Execute Test Cases
+      run: |
+        cargo test --workspace --verbose
 
-    # save the pyrsia_node binary for the package creation
-    - name: Save pyrsia_node binary
-      uses: actions/upload-artifact@v2
-      if: runner.os == 'Linux'
-      with:
-        name: pyrsia_node
-        path: target/release/pyrsia_node
-        if-no-files-found: error
-
-    # save the pyrsia binary for the package creation
-    - name: Save pyrsia binary
-      uses: actions/upload-artifact@v2
-      if: runner.os == 'Linux'
-      with:
-        name: pyrsia
-        path: target/release/pyrsia
-        if-no-files-found: error
-
-    # save the debian control files to be used with the deb packager
-    - name: Save debian control file
-      uses: actions/upload-artifact@v2
-      if: runner.os == 'Linux'
-      with:
-        name: DEBIAN
-        path: installers/DEBIAN
-        if-no-files-found: error
-    
-      # build synapse-bt 1.0 from github (commit:634ee2a62 = 1.0 tag)
-    - name: Build synapse 
+    - name: Strip Binaries
       if: runner.os == 'Linux'
       run: |
-        cargo install --force --git https://github.com/Luminarys/synapse.git#634ee2a62 synapse-bt
-        cp ~/.cargo/bin/synapse target/release/synapse
-      shell: bash
+        cargo strip
 
-    # save the debian control files to be used with the deb packager
-    - name: Save synapse binary
-      uses: actions/upload-artifact@v2
+    # Create Pyrsia .deb file
+    - name: Package Pyrsia as deb file
       if: runner.os == 'Linux'
+      uses: actions-rs/cargo@v1.0.1
       with:
-        name: synapse
-        path: target/release/synapse
-        if-no-files-found: error
+        command: deb
+        args: --no-build -v
 
-  # Create the .deb file, add it to the apt repo and
+    # Add the prysia .deb file to the apt repo which is part of
+    # the github website repo
+    - name: Upload Pyrsia .deb to website repo
+      uses: sbtaylor15/apt-repo-action@v2.0.4
+      # Only when we push on the main repository should we upload the results
+      if: github.repository_owner == 'pyrsia' && github.event_name == 'push' && runner.os == 'Linux'
+      with:
+        github_token: ${{ secrets.APT }}
+        repo_supported_version: |
+          focal
+        repo_supported_arch: |
+          amd64
+        page_branch: gh-pages
+        file: /github/workspace/target/debian/pyrsia_0.1.0+${{ github.run_number }}_amd64.deb
+        file_target_version: focal
+        public_key: ${{ secrets.GPG_PUBLIC }}
+        private_key: ${{ secrets.GPG_PRIVATE }}
+        key_passphrase: ${{ secrets.GPG_SECRET }}
+        github_repository: pyrsia/pyrsia.github.io
+    
+  # Create the Synapse binaries and .deb file, add it to the apt repo and
   # push the changes to the website github repo
-  apt-package:
+  synapse-package:
       needs: [build]
       runs-on: ubuntu-latest
       steps:
+      # Install cargo deb and strip
+      - name: Install cargo-deb
+        uses: actions-rs/cargo@v1.0.1
+        with: 
+          command: install
+          args: cargo-deb cargo-strip --force
 
-      # grab the pyrsia_node from the build step
-      - name: Fetch pyrsia_node binary
-        uses: actions/download-artifact@v2
+      # Checkout Synapse
+      - name: Checkout Synapse
+        uses: actions/checkout@v2
         with:
-          name: pyrsia_node
-          path: target/release
+          repository: pyrsia/synapse
 
-      # grab the pyrsia from the build step
-      - name: Fetch pyrsia binary
-        uses: actions/download-artifact@v2
-        with:
-          name: pyrsia
-          path: target/release
-
-      # grab the control file from the build step
-      - name: Fetch debian control file
-        uses: actions/download-artifact@v2
-        with:
-          name: DEBIAN
-          path: pyrsia/DEBIAN
-
-      # grab the synapse from the build step
-      - name: Fetch synapse binary
-        uses: actions/download-artifact@v2
-        with:
-          name: synapse
-          path: target/release
-
-      # create the pyrsia.deb file
-      - name:  Package for apt-get
+      # Need to add build number to version number
+      - name: Iterate Build Version Number
         run: |
-            mkdir -p pyrsia/usr/local/bin
-            cp target/release/pyrsia_node pyrsia/usr/local/bin
-            cp target/release/pyrsia pyrsia/usr/local/bin
-            cp target/release/synapse pyrsia/usr/local/bin
-            chmod 755 pyrsia/usr/local/bin/pyrsia_node
-            chmod 755 pyrsia/usr/local/bin/pyrsia
-            chmod 755 pyrsia/usr/local/bin/synapse
-            echo "Installed-Size: $(echo "$(stat -c%s pyrsia/usr/local/bin/pyrsia) + $(stat -c%s pyrsia/usr/local/bin/pyrsia_node)" | bc)" >> pyrsia/DEBIAN/control
-            sed -i.bak "/Version:/s/\$/-$GITHUB_RUN_NUMBER/" pyrsia/DEBIAN/control
-            cat pyrsia/DEBIAN/control
-            dpkg-deb --build pyrsia
-            ls -la pyrsia.deb
-        shell: bash
+          sed -i.bak "/^version = \"1.0.0\"/s/\"\$/+${{ github.run_number }}\"/" Cargo.toml
 
-      # add the prysia.deb file to the apt repo which is part of
+      # Create the Synapse Binaries
+      - name: Build Synapse
+        run: |
+          cargo build --workspace   --release
+      
+      - name: Strip Synapse
+        run: |
+          cargo strip
+
+      # Create Synapse .deb file
+      - name: Package Synapse as deb file
+        uses: actions-rs/cargo@v1.0.1
+        with:
+          command: deb
+          args: --no-build -v
+
+      # Add the synapse .deb file to the apt repo which is part of
       # the github website repo
-      - uses: sbtaylor15/apt-repo-action@v2.0.4
+      - name: Updload Synapse .deb to website repo
+        uses: sbtaylor15/apt-repo-action@v2.0.4
         # Only when we push on the main repository should we upload the results
         if: github.repository_owner == 'pyrsia' && github.event_name == 'push'
         with:
           github_token: ${{ secrets.APT }}
           repo_supported_version: |
-            bionic
+            focal
           repo_supported_arch: |
             amd64
           page_branch: gh-pages
-          file: /github/workspace/pyrsia.deb
-          file_target_version: bionic
+          file: /github/workspace/target/debian/synapse-bt_1.0.0+${{ github.run_number }}_amd64.deb
+          file_target_version: focal
           public_key: ${{ secrets.GPG_PUBLIC }}
           private_key: ${{ secrets.GPG_PRIVATE }}
           key_passphrase: ${{ secrets.GPG_SECRET }}
-          github_repository: pyrsia/website
+          github_repository: pyrsia/pyrsia.github.io
 
   coverage:
     needs: [build]
@@ -185,7 +181,7 @@ jobs:
   
   docker:
     runs-on: ubuntu-latest
-    needs: [apt-package]
+    needs: [build, synapse-package]
     if: github.repository_owner == 'pyrsia' && github.event_name == 'push'
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,7 +40,7 @@ jobs:
         args: cargo-deb cargo-strip --force
 
     # Need to add build number to version number
-    - name: Iterate Build Version Number
+    - name: Add Build to Version Number
       run: |
         sed -i.bak "/^version = \"0.1.0\"/s/\"\$/+${{ github.run_number }}\"/" Cargo.toml
 
@@ -105,7 +105,7 @@ jobs:
           repository: pyrsia/synapse
 
       # Need to add build number to version number
-      - name: Iterate Build Version Number
+      - name: Add Build to Version Number
         run: |
           sed -i.bak "/^version = \"1.0.0\"/s/\"\$/+${{ github.run_number }}\"/" Cargo.toml
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,24 @@
 [package]
 name = "pyrsia"
+readme = "readme.md"
 version = "0.1.0"
 edition = "2021"
+description = "Prysia Node and CLI"
+authors = ["pyrsiaoss <pyrsiaopensource@gmail.com>"]
+license = "Apache-2"
+repository = "https://github.com/pyrsia/pyrsia"
+
+[package.metadata.deb]
+assets = [
+    ["target/release/pyrsia_node", "usr/bin/", "755"],
+    ["target/release/pyrsia", "usr/bin/", "755"],
+    ["readme.md", "usr/share/doc/pyrsia/README", "644"],
+    ["installers/debian/synapse.toml", "usr/share/pyrsia/synapse.toml", "644"]
+   ]
+section = "devel"
+depends = "openssl, synapse-bt"
+maintainer-scripts = "installers/debian/"
+systemd-units = { unit-name = "pyrsia", unit-scripts = "installers/debian/" }
 
 [dependencies]
 signed = {path="src/signed"}

--- a/installers/DEBIAN/control
+++ b/installers/DEBIAN/control
@@ -1,9 +1,0 @@
-Package: pyrsia
-Version: 0.1.0
-Section: custom
-Priority: optional
-Architecture: amd64
-Essential: no
-Maintainer: pyrsia.io
-Description: Pyrsia Node and CLI
-Depends: openssl

--- a/installers/debian/postinst
+++ b/installers/debian/postinst
@@ -1,10 +1,11 @@
-#!/bin/sh -e
+#!/usr/bin/env bash
 
 /usr/bin/systemctl stop synapse-bt
 export PW=`echo ZG9udGhhY2ttZQ== | base64 -d`
-sed -i.bak "s/hackme/$PW/" /usr/share/pyrsia/synapse.toml
-sed -i.bak "s#/usr/local/share/synapse/synapse.toml#/usr/local/share/pyrsia/synapse.toml#" /lib/systemd/system/synapse-bt.service
+/usr/bin/sed/sed -i.bak "s/hackme/$PW/" /usr/share/pyrsia/synapse.toml
+/usr/bin/sed/sed -i.bak "s#/usr/local/share/synapse/synapse.toml#/usr/local/share/pyrsia/synapse.toml#" /lib/systemd/system/synapse-bt.service
 /usr/bin/systemctl daemon-reload
 /usr/bin/systemctl start synapse-bt
 
 #DEBHELPER#
+

--- a/installers/debian/postinst
+++ b/installers/debian/postinst
@@ -1,0 +1,10 @@
+#!/bin/sh -e
+
+/usr/bin/systemctl stop synapse-bt
+export PW=`echo ZG9udGhhY2ttZQ== | base64 -d`
+sed -i.bak "s/hackme/$PW/" /usr/share/pyrsia/synapse.toml
+sed -i.bak "s#/usr/local/share/synapse/synapse.toml#/usr/local/share/pyrsia/synapse.toml#" /lib/systemd/system/synapse-bt.service
+/usr/bin/systemctl daemon-reload
+/usr/bin/systemctl start synapse-bt
+
+#DEBHELPER#

--- a/installers/debian/postrm
+++ b/installers/debian/postrm
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+#DEBHELPER#

--- a/installers/debian/postrm
+++ b/installers/debian/postrm
@@ -1,3 +1,4 @@
-#!/bin/sh -e
+#!/usr/bin/env bash
 
 #DEBHELPER#
+

--- a/installers/debian/preinst
+++ b/installers/debian/preinst
@@ -1,6 +1,7 @@
-#!/bin/sh -e
+#!/usr/bin/env bash
 
 mkdir -p /usr/local/var/pyrsia 2>/dev/null
 chmod -R 644 /usr/local/var/pyrsia
 
 #DEBHELPER#
+

--- a/installers/debian/preinst
+++ b/installers/debian/preinst
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+
+mkdir -p /usr/local/var/pyrsia 2>/dev/null
+chmod -R 644 /usr/local/var/pyrsia
+
+#DEBHELPER#

--- a/installers/debian/prerm
+++ b/installers/debian/prerm
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+#DEBHELPER#

--- a/installers/debian/prerm
+++ b/installers/debian/prerm
@@ -1,3 +1,4 @@
-#!/bin/sh -e
+#!/usr/bin/env bash
 
 #DEBHELPER#
+

--- a/installers/debian/pyrsia.service
+++ b/installers/debian/pyrsia.service
@@ -9,3 +9,4 @@ ExecStart=/usr/bin/pyrsia_node
 
 [Install]
 WantedBy=multi-user.target
+

--- a/installers/debian/pyrsia.service
+++ b/installers/debian/pyrsia.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Pyrsia Node
+
+[Service]
+WorkingDirectory=/usr/local/var
+Environment="PYRSIA_ARTIFACT_PATH=/usr/local/var/pyrsia"
+Environment="RUST_LOG=info"
+ExecStart=/usr/bin/pyrsia_node
+
+[Install]
+WantedBy=multi-user.target

--- a/installers/debian/synapse.toml
+++ b/installers/debian/synapse.toml
@@ -51,3 +51,4 @@ max_open_announces = 50
 # a connection is eligible for forced pruning
 # when the max socket limit is reached
 prune_timeout = 15
+

--- a/installers/debian/synapse.toml
+++ b/installers/debian/synapse.toml
@@ -1,0 +1,53 @@
+# TCP port used for peer connections
+port = 16493
+
+# Maximum number of downloading torrents
+max_dl = 10
+
+[rpc]
+# TCP port used for RPC
+port = 8412
+# Whether or not RPC should listen on localhost
+# or 0.0.0.0
+local = true
+# Whether or not RPC should use auth
+# WARNING: If you do not use auth, synapse is still insecure, even running locally!
+auth = true
+# Password to use for auth.
+password = "hackme"
+# Optional SSL full certificate chain and key file (PEM only)
+# ssl_cert = "./cert.pem"
+# If SSL key is encrypted, you will need to enter your password at start
+# ssl_key = "./key.pem"
+
+[tracker]
+# UDP port used for UDP tracker interaction
+port = 16362
+
+[dht]
+# UDP port used for DHT interaction
+port = 16309
+# Node to use for DHT bootstrapping.
+# If this is not specified, DHT will be disabled.
+#bootstrap_node = "router.bittorrent.com:6881"
+bootstrap_node = "dht.transmissionbt.com:6881"
+
+[disk]
+# Location for storing session metadata
+session = "/usr/local/var/synapse/"
+# Default download directory
+directory = "/usr/local/var/prysia/"
+
+[net]
+# These max open limits should be set to be somewhat lower
+# than whatever the system ulimit is to accomodate for internal
+# fd's
+max_open_files = 500
+max_open_sockets = 400
+max_open_announces = 50
+
+[peer]
+# Duration(in seconds) of inactivity before
+# a connection is eligible for forced pruning
+# when the max socket limit is reached
+prune_timeout = 15


### PR DESCRIPTION
- Replaced dpkg-deb with the cargo-deb action.

  cargo-deb uses key/values from the Cargo.toml as input to create the .deb file.  One of the required fields is the `version` number.  This was changed from 0.1.0 to 0.1.0+&lt;build number&gt; per the [semver.org](https://semver.org/).  The build number was added to make the new .deb file unique.  Debian repositories are set up so you cannot replace existing versions.  Instead, you must iterate the version number to add updates.   Adding the build number allows us to iterate the version number but keeps the main version pinned to 0.1.0.   

  Since the version number is in the Cargo.toml and it is being updated, --locked had to be removed as part of the build.  --offline was tested but the pyrsia/synapse is a dependency that is not cached locally but is being built as well. 

- Use cargo-strip to reduce the size of the binaries.  

  cargo-strip runs the OS level `strip` program to remove debug and unused symbols.  This is equivalent to running the linker with the `-s` parameter.

- Added pyrsia/synapse build to pyrsia/pyrsia Rust Workflow.  This was done to minimize token setup and synchronization issues across repositories.  Synapse is being built in its own Job in order to prevent errors when cloning another repository into a  workspace of pyrsia/pyrsia.

- Added service install and service configuration for Pyrsia and Synapse.

  cargo-deb will create and install the services under `systemd`.   `RUST_LOG=info` and `PYRSIA_ARTIFACT_PATH=/usr/local/var/pyrsia` environment variables are set up as well.  Synapse will startup under its default configuration.  Pyrsia install will reconfigure Synapse service to use its configuration file.  

  Directory and File Layout:
  - /usr/bin/pyrsia_node
  - /usr/bin/pyrsia
  - /usr/share/doc/pyrsia/README
  - /usr/share/pyrsia/synapse.toml
  - /usr/bin/synapse
  - /usr/share/doc/synapse/README
  - /usr/local/share/synapse/synapse.toml
  - /usr/local/share/synapse/sycli.toml

See #300
Resolves #314, #302, #251, #129
