### PR TITLE
Create blockchain::network.rs and blockchain::storage.rs to handle all related structs and methods

### DIFF
--- a/src/blockchain/examples/simple_node.rs
+++ b/src/blockchain/examples/simple_node.rs
@@ -79,7 +79,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Create a Swarm to manage peers and events.
     let mut swarm = {
         let mdns = Mdns::new(Default::default()).await?;
-        let mut behaviour = network::MyBehaviour {
+        let mut behaviour = network::Behaviour {
             floodsub: Floodsub::new(peer_id),
             mdns,
         };

--- a/src/blockchain/examples/simple_node.rs
+++ b/src/blockchain/examples/simple_node.rs
@@ -21,16 +21,15 @@ extern crate tokio;
 use futures::StreamExt;
 use libp2p::{
     core::upgrade,
-    floodsub::{self, Floodsub, FloodsubEvent},
+    floodsub::{self, Floodsub},
     identity,
-    mdns::{Mdns, MdnsEvent},
+    mdns::Mdns,
     mplex,
     noise,
-    swarm::{NetworkBehaviourEventProcess, SwarmBuilder, SwarmEvent},
+    swarm::{SwarmBuilder, SwarmEvent},
     // `TokioTcpConfig` is available through the `tcp-tokio` feature.
     tcp::TokioTcpConfig,
     Multiaddr,
-    NetworkBehaviour,
     PeerId,
     Transport,
 };
@@ -40,7 +39,6 @@ use rand::Rng;
 use std::error::Error;
 use tokio::io::{self, AsyncBufReadExt};
 
-pub const BLOCK_FILE_PATH: &str = "./blockchain_storage";
 pub const CONTINUE_COMMIT: &str = "1"; //allow to continuously commit
 pub const APART_ONE_COMMIT: &str = "2"; //must be at least one ledger apart to commit
 
@@ -53,7 +51,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     println!("Local peer id: {:?}", peer_id);
     let filepath = match std::env::args().nth(1) {
         Some(v) => v,
-        None => String::from(BLOCK_FILE_PATH),
+        None => String::from(storage::BLOCK_FILE_PATH),
     };
 
     // Create a keypair for authenticated encryption of the transport.
@@ -77,58 +75,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // The derive generates a delegating `NetworkBehaviour` impl which in turn
     // requires the implementations of `NetworkBehaviourEventProcess` for
     // the events of each behaviour.
-    #[derive(NetworkBehaviour)]
-    #[behaviour(event_process = true)]
-    // TODO(prince-chrismc): Give this a much better name!
-    struct MyBehaviour {
-        floodsub: Floodsub,
-        mdns: Mdns,
-    }
-
-    impl NetworkBehaviourEventProcess<FloodsubEvent> for MyBehaviour {
-        // Called when `floodsub` produces an event.
-        fn inject_event(&mut self, message: FloodsubEvent) {
-            if let FloodsubEvent::Message(message) = message {
-                //println!("Received: '{:?}' from {:?}", &message.data, message.source);
-                let block: block::Block =
-                    bincode::deserialize::<block::Block>(&message.data).unwrap();
-                println!("++++++++++"); // TODO(fishseasbowl): Replace with logging methods
-                println!("++++++++++");
-                println!("Recevie a new block {:?}", block);
-                let filepath = match std::env::args().nth(1) {
-                    Some(v) => v,
-                    None => String::from("./first"),
-                };
-
-                write_block(filepath, block);
-            }
-        }
-    }
-
-    impl NetworkBehaviourEventProcess<MdnsEvent> for MyBehaviour {
-        // Called when `mdns` produces an event.
-        fn inject_event(&mut self, event: MdnsEvent) {
-            match event {
-                MdnsEvent::Discovered(list) => {
-                    for (peer, _) in list {
-                        self.floodsub.add_node_to_partial_view(peer);
-                    }
-                }
-                MdnsEvent::Expired(list) => {
-                    for (peer, _) in list {
-                        if !self.mdns.has_node(&peer) {
-                            self.floodsub.remove_node_from_partial_view(&peer);
-                        }
-                    }
-                }
-            }
-        }
-    }
 
     // Create a Swarm to manage peers and events.
     let mut swarm = {
         let mdns = Mdns::new(Default::default()).await?;
-        let mut behaviour = MyBehaviour {
+        let mut behaviour = network::MyBehaviour {
             floodsub: Floodsub::new(peer_id),
             mdns,
         };
@@ -186,7 +137,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     &ed25519_keypair,
                 );
                 transactions.push(transaction);
-                let (parent_hash, previous_number, previous_commiter)=read_last_block(filepath.clone());
+                let (parent_hash, previous_number, previous_commiter)=storage::read_last_block(filepath.clone());
                 //let parent_hash=header::hash(b"");
                 //let previous_number=0;
 
@@ -201,7 +152,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 println!("---------");
                 println!("Add a New Block : {:?}", block);
                 swarm.behaviour_mut().floodsub.publish(floodsub_topic.clone(), bincode::serialize(&block).unwrap());
-                write_block(filepath.clone(), block);
+                storage::write_block(filepath.clone(), block);
             }
             event = swarm.select_next_some() => {
                 if let SwarmEvent::NewListenAddr { address, .. } = event {
@@ -212,97 +163,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
 }
 
-//Add genesis block to the file
-pub fn append_genesis_block(path: String, key: &identity::ed25519::Keypair) {
-    use blockchain::GenesisBlock;
-    use std::fs::OpenOptions;
-    use std::io::Write;
-
-    let g_block = GenesisBlock::new(key);
-    let mut file = OpenOptions::new()
-        .create_new(true)
-        .write(true)
-        .append(true)
-        .open(path)
-        .expect("cannot open file");
-
-    file.write_all(&bincode::serialize(&g_block).unwrap())
-        .expect("write failed");
-}
-
-//read a last block from the file, and return this block hash, this block number and this block committer
-pub fn read_last_block(path: String) -> (header::HashDigest, u128, header::Address) {
-    use std::io::{BufRead, BufReader};
-    let file = std::fs::File::open(path).unwrap();
-
-    let buffered = BufReader::new(file);
-    let line = buffered.lines().last().expect("stdin to read").unwrap();
-    let block: block::Block = serde_json::from_str(&line).unwrap();
-
-    (
-        block.header.current_hash,
-        block.header.number,
-        block.header.committer,
-    )
-}
-
-//Write a block to the file
-pub fn write_block(path: String, block: block::Block) {
-    use std::fs::OpenOptions;
-    use std::io::Write;
-
-    let mut file = OpenOptions::new()
-        .create_new(true)
-        .write(true)
-        .append(true)
-        .open(path)
-        .expect("cannot open file");
-
-    file.write_all(serde_json::to_string(&block).unwrap().as_bytes())
-        .expect("write failed");
-    file.write_all(b"\n").expect("write failed");
-}
-
 #[cfg(test)]
 mod tests {
     extern crate pyrsia_blockchain_network;
     use super::*;
-    use libp2p::identity;
-    use pyrsia_blockchain_network::{block, header};
-    use rand::Rng;
-
-    #[test]
-    fn test_write_read() -> Result<(), String> {
-        let keypair = identity::ed25519::Keypair::generate();
-        let local_id = header::hash(&block::get_publickey_from_keypair(&keypair).encode());
-        let mut transactions = vec![];
-        let data = "Hello First Transaction";
-        let transaction = block::Transaction::new(
-            block::PartialTransaction::new(
-                block::TransactionType::Create,
-                local_id,
-                data.as_bytes().to_vec(),
-                rand::thread_rng().gen::<u128>(),
-            ),
-            &keypair,
-        );
-        transactions.push(transaction);
-        let block_header = header::Header::new(header::PartialHeader::new(
-            header::hash(b""),
-            local_id,
-            header::hash(b""),
-            1,
-            rand::thread_rng().gen::<u128>(),
-        ));
-
-        let block = block::Block::new(block_header, transactions.to_vec(), &keypair);
-        append_genesis_block(BLOCK_FILE_PATH.to_string(), &keypair);
-        write_block(BLOCK_FILE_PATH.to_string(), block);
-        let (_, number, _) = read_last_block(BLOCK_FILE_PATH.to_string());
-
-        assert_eq!(1, number);
-        Ok(())
-    }
 
     #[test]
     fn test_main() -> Result<(), String> {

--- a/src/blockchain/examples/simple_node.rs
+++ b/src/blockchain/examples/simple_node.rs
@@ -121,6 +121,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let mut transactions = vec![];
 
+    storage::append_genesis_block(filepath.clone(), &ed25519_keypair);
+
     let local_id = header::hash(&block::get_publickey_from_keypair(&ed25519_keypair).encode());
     // Kick it off
     loop {
@@ -138,8 +140,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 );
                 transactions.push(transaction);
                 let (parent_hash, previous_number, previous_commiter)=storage::read_last_block(filepath.clone());
-                //let parent_hash=header::hash(b"");
-                //let previous_number=0;
 
                 if check_number==APART_ONE_COMMIT && previous_commiter == local_id{
 
@@ -165,9 +165,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
 #[cfg(test)]
 mod tests {
-    extern crate pyrsia_blockchain_network;
     use super::*;
-
     #[test]
     fn test_main() -> Result<(), String> {
         let result = main();

--- a/src/blockchain/src/lib.rs
+++ b/src/blockchain/src/lib.rs
@@ -17,3 +17,5 @@
 pub mod block;
 pub mod blockchain;
 pub mod header;
+pub mod network;
+pub mod storage;

--- a/src/blockchain/src/network.rs
+++ b/src/blockchain/src/network.rs
@@ -25,7 +25,7 @@ use super::*;
 #[derive(NetworkBehaviour)]
 #[behaviour(event_process = true)]
 
-pub struct MyBehaviour {
+pub struct Behaviour {
     pub floodsub: Floodsub,
     pub mdns: Mdns,
 }

--- a/src/blockchain/src/network.rs
+++ b/src/blockchain/src/network.rs
@@ -30,7 +30,7 @@ pub struct Behaviour {
     pub mdns: Mdns,
 }
 
-impl NetworkBehaviourEventProcess<FloodsubEvent> for MyBehaviour {
+impl NetworkBehaviourEventProcess<FloodsubEvent> for Behaviour {
     // Called when `floodsub` produces an event.
     fn inject_event(&mut self, message: FloodsubEvent) {
         if let FloodsubEvent::Message(message) = message {
@@ -49,7 +49,7 @@ impl NetworkBehaviourEventProcess<FloodsubEvent> for MyBehaviour {
     }
 }
 
-impl NetworkBehaviourEventProcess<MdnsEvent> for MyBehaviour {
+impl NetworkBehaviourEventProcess<MdnsEvent> for Behaviour {
     // Called when `mdns` produces an event.
     fn inject_event(&mut self, event: MdnsEvent) {
         match event {

--- a/src/blockchain/src/network.rs
+++ b/src/blockchain/src/network.rs
@@ -1,0 +1,70 @@
+/*
+   Copyright 2021 JFrog Ltd
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+use libp2p::{
+    floodsub::{Floodsub, FloodsubEvent},
+    mdns::{Mdns, MdnsEvent},
+    swarm::NetworkBehaviourEventProcess,
+    NetworkBehaviour,
+};
+
+use super::*;
+
+#[derive(NetworkBehaviour)]
+#[behaviour(event_process = true)]
+
+pub struct MyBehaviour {
+    pub floodsub: Floodsub,
+    pub mdns: Mdns,
+}
+
+impl NetworkBehaviourEventProcess<FloodsubEvent> for MyBehaviour {
+    // Called when `floodsub` produces an event.
+    fn inject_event(&mut self, message: FloodsubEvent) {
+        if let FloodsubEvent::Message(message) = message {
+            //println!("Received: '{:?}' from {:?}", &message.data, message.source);
+            let block: block::Block = bincode::deserialize::<block::Block>(&message.data).unwrap();
+            println!("++++++++++"); // TODO(fishseasbowl): Replace with logging methods
+            println!("++++++++++");
+            println!("Recevie a new block {:?}", block);
+            let filepath = match std::env::args().nth(1) {
+                Some(v) => v,
+                None => String::from("./first"),
+            };
+
+            storage::write_block(filepath, block);
+        }
+    }
+}
+
+impl NetworkBehaviourEventProcess<MdnsEvent> for MyBehaviour {
+    // Called when `mdns` produces an event.
+    fn inject_event(&mut self, event: MdnsEvent) {
+        match event {
+            MdnsEvent::Discovered(list) => {
+                for (peer, _) in list {
+                    self.floodsub.add_node_to_partial_view(peer);
+                }
+            }
+            MdnsEvent::Expired(list) => {
+                for (peer, _) in list {
+                    if !self.mdns.has_node(&peer) {
+                        self.floodsub.remove_node_from_partial_view(&peer);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/blockchain/src/storage.rs
+++ b/src/blockchain/src/storage.rs
@@ -1,0 +1,111 @@
+/*
+   Copyright 2021 JFrog Ltd
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+use super::*;
+use libp2p::identity;
+
+pub const BLOCK_FILE_PATH: &str = "./blockchain_storage";
+
+//Add genesis block to the file
+pub fn append_genesis_block(path: String, key: &identity::ed25519::Keypair) {
+    use blockchain::GenesisBlock;
+    use std::fs::OpenOptions;
+    use std::io::Write;
+
+    let g_block = GenesisBlock::new(key);
+    let mut file = OpenOptions::new()
+        .write(true)
+        .append(true)
+        .create(true)
+        .open(path)
+        .expect("cannot open file");
+
+    file.write_all(serde_json::to_string(&g_block).unwrap().as_bytes())
+        .expect("write failed");
+    file.write_all(b"\n").expect("write failed");
+}
+
+//read a last block from the file, and return this block hash, this block number and this block committer
+pub fn read_last_block(path: String) -> (header::HashDigest, u128, header::Address) {
+    use std::io::{BufRead, BufReader};
+    let file = std::fs::File::open(path).unwrap();
+
+    let buffered = BufReader::new(file);
+    let line = buffered.lines().last().expect("stdin to read").unwrap();
+    let block: block::Block = serde_json::from_str(&line).unwrap();
+
+    (
+        block.header.current_hash,
+        block.header.number,
+        block.header.committer,
+    )
+}
+
+//Write a block to the file
+pub fn write_block(path: String, block: block::Block) {
+    use std::fs::OpenOptions;
+    use std::io::Write;
+
+    let mut file = OpenOptions::new()
+        .write(true)
+        .append(true)
+        .create(true)
+        .open(path)
+        .expect("cannot open file");
+
+    file.write_all(serde_json::to_string(&block).unwrap().as_bytes())
+        .expect("write failed");
+    file.write_all(b"\n").expect("write failed");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use libp2p::identity;
+    use rand::Rng;
+
+    #[test]
+    fn test_write_read() -> Result<(), String> {
+        let keypair = identity::ed25519::Keypair::generate();
+        let local_id = header::hash(&block::get_publickey_from_keypair(&keypair).encode());
+        let mut transactions = vec![];
+        let data = "Hello First Transaction";
+        let transaction = block::Transaction::new(
+            block::PartialTransaction::new(
+                block::TransactionType::Create,
+                local_id,
+                data.as_bytes().to_vec(),
+                rand::thread_rng().gen::<u128>(),
+            ),
+            &keypair,
+        );
+        transactions.push(transaction);
+        let block_header = header::Header::new(header::PartialHeader::new(
+            header::hash(b""),
+            local_id,
+            header::hash(b""),
+            1,
+            rand::thread_rng().gen::<u128>(),
+        ));
+
+        let block = block::Block::new(block_header, transactions.to_vec(), &keypair);
+        append_genesis_block(BLOCK_FILE_PATH.to_string(), &keypair);
+        write_block(BLOCK_FILE_PATH.to_string(), block);
+        let (_, number, _) = read_last_block(BLOCK_FILE_PATH.to_string());
+
+        assert_eq!(1, number);
+        Ok(())
+    }
+}

--- a/src/blockchain/src/storage.rs
+++ b/src/blockchain/src/storage.rs
@@ -44,7 +44,11 @@ pub fn read_last_block(path: String) -> (header::HashDigest, u128, header::Addre
 
     let buffered = BufReader::new(file);
     let line = buffered.lines().last().expect("stdin to read").unwrap();
-    let block: block::Block = serde_json::from_str(&line).unwrap();
+
+    let block: block::Block = match serde_json::from_str(&line) {
+        Ok(v) => v,
+        Err(_) => return parse_genesis_block(&line),
+    };
 
     (
         block.header.current_hash,
@@ -53,6 +57,15 @@ pub fn read_last_block(path: String) -> (header::HashDigest, u128, header::Addre
     )
 }
 
+// Unformat the genesis block json string
+pub fn parse_genesis_block(line: &String) -> (header::HashDigest, u128, header::Address) {
+    let genesis_block: blockchain::GenesisBlock = serde_json::from_str(line).unwrap();
+    (
+        genesis_block.header.current_hash,
+        genesis_block.header.number,
+        genesis_block.header.committer,
+    )
+}
 //Write a block to the file
 pub fn write_block(path: String, block: block::Block) {
     use std::fs::OpenOptions;


### PR DESCRIPTION
This PR creates two separate files: network.rs and storage.rs to handle related structs and methods, making the code easer to understand. 

This PR closes #332 and #340 issues

Unit test: test_write_read()