### PR TITLE
Replaced ART_MGR_DIR to get path value from env var

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -12,7 +12,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y wget gnupg
           wget -qO - https://pyrsia.io/public.key | sudo apt-key add -
-          echo "deb https://pyrsia.io/repo bionic main" | sudo tee -a /etc/apt/sources.list > /dev/null
+          echo "deb https://pyrsia.io/repo focal main" | sudo tee -a /etc/apt/sources.list > /dev/null
           sudo apt-get update
           sudo apt-get install -y pyrsia
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e22d1f4b888c298a027c99dc9048015fac177587de20fc30232a057dfbe24a21"
 
 [[package]]
+name = "assay"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "238d82aacd5cfde8ccae5c981912be68ec3cfa2d92ff4ce34090be40584c96a6"
+dependencies = [
+ "assay-proc-macro",
+ "pretty_assertions",
+ "rusty-fork",
+ "tempdir",
+ "tokio",
+]
+
+[[package]]
+name = "assay-proc-macro"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5fd637c6a75fe224b372556511913f12d6ad481fbfef2fb7ecea2f7cb4965d"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,6 +955,12 @@ dependencies = [
  "openssl",
  "serde_json",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
 name = "digest"
@@ -2827,6 +2856,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "output_vt100"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "owning_ref"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3048,6 +3086,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
+name = "pretty_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d5b548b725018ab5496482b45cb8bef21e9fed1858a6d674e3a8a0f0bb5d50"
+dependencies = [
+ "ansi_term",
+ "ctor",
+ "diff",
+ "output_vt100",
+]
+
+[[package]]
 name = "pretty_env_logger"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3169,6 +3219,7 @@ name = "pyrsia"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assay",
  "base64 0.9.3",
  "bincode",
  "blake3",
@@ -3306,6 +3357,19 @@ checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
@@ -3411,6 +3475,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
  "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -3556,6 +3629,18 @@ dependencies = [
  "ring",
  "sct",
  "webpki",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -4082,6 +4167,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4530,6 +4625,15 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "waker-fn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ features = []
 [dev-dependencies]
 string_manipulation = {path="tests/string_manipulation"}
 expectest = "0.10.0"
+assay = "0.1.0"
 
 [workspace]
 members = [

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ COPY --from=dupdatelock /src/Cargo.lock .
 FROM builder AS dbuild
 RUN mkdir -p /out
 ENV RUST_BACKTRACE=1
+ENV DEV_MODE=on 
+ENV PYRSIA_ARTIFACT_PATH=pyrsia
 RUN --mount=target=/src \
     --mount=type=cache,target=/target \
     --mount=type=cache,target=/usr/local/cargo/git/db \

--- a/installers/docker/AptGet.Dockerfile
+++ b/installers/docker/AptGet.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:focal
 
 EXPOSE 7888
 

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ For now Pyrsia only supports Docker artifacts. Follow these steps to run a Pyrsi
 2. Clone this repo `git clone https://github.com/pyrsia/pyrsia.git`
 3. `cd pyrsia/pyrsia_node`
 4. You need to start the Pyrsia Node. To do so, you have 2 options:
-   - regular build: `cargo run`
+   - regular build: `DEV_MODE=on PYRSIA_ARTIFACT_PATH=pyrsia cargo run`
    - build in docker: `docker-compose up --build`
 
 *Note*: Do not to stop this process, a running node is required for the 
@@ -110,15 +110,15 @@ the Pyrsia node is running.
 10. Multiple Pyrsia nodes can be started on the same computer by changing the ports they use as follows
 
     ```
-    cargo run --bin pyrsia_node -- -p 7888
+    DEV_MODE=on PYRSIA_ARTIFACT_PATH=pyrsia cargo run --bin pyrsia_node -- -p 7888
 
-    # RUST_LOG=debug cargo run --bin pyrsia_node -- -p 7888 # Use this environment variable if you would like to see debug logs
+    # RUST_LOG=debug DEV_MODE=on PYRSIA_ARTIFACT_PATH=pyrsia cargo run --bin pyrsia_node -- -p 7888 # Use this environment variable if you would like to see debug logs
     ```
 
     ```
-    cargo run --bin pyrsia_node -- -p 8181
+    DEV_MODE=on PYRSIA_ARTIFACT_PATH=pyrsia cargo run --bin pyrsia_node -- -p 8181
 
-    # RUST_LOG=debug cargo run --bin pyrsia_node -- -p 8181 # Use this environment variable if you would like to see debug logs
+    # RUST_LOG=debug DEV_MODE=on PYRSIA_ARTIFACT_PATH=pyrsia cargo run --bin pyrsia_node -- -p 8181 # Use this environment variable if you would like to see debug logs
     ```
 
     ```

--- a/src/docker/v2/handlers/blobs.rs
+++ b/src/docker/v2/handlers/blobs.rs
@@ -257,7 +257,7 @@ fn store_blob_in_filesystem(
     let append = append_to_blob(&blob_upload_dest_data, bytes)?;
 
     // check if there is enough local allocated disk space
-    let available_space = get_space_available(ARTIFACTS_DIR);
+    let available_space = get_space_available(ARTIFACTS_DIR.as_str());
     if available_space.is_err() {
         return Err(available_space.err().unwrap().to_string().into());
     }

--- a/src/docker/v2/handlers/manifests.rs
+++ b/src/docker/v2/handlers/manifests.rs
@@ -821,7 +821,6 @@ mod tests {
             async { handle_get_manifests("hello-world".to_string(), "v3.1".to_string()).await };
         let result = executor::block_on(future);
         check_get_manifest_result(result);
-        remove_dir_all(&env::var("PYRSIA_ARTIFACT_PATH").unwrap());
     }
 
     fn check_package_version_metadata() -> anyhow::Result<()> {
@@ -872,13 +871,6 @@ mod tests {
         assert!(!manifest_content.is_empty());
         assert_eq!(4698, manifest_content.len());
         Ok(())
-    }
-
-    fn remove_dir_all(dir_name: &String) {
-        if Path::new(dir_name).exists() {
-            fs::remove_dir_all(dir_name.clone())
-                .expect(&format!("unable to remove test directory {}", dir_name));
-        }
     }
 
     #[test]

--- a/src/docker/v2/handlers/manifests.rs
+++ b/src/docker/v2/handlers/manifests.rs
@@ -650,6 +650,7 @@ mod tests {
     use serde::de::StdError;
     use std::env;
     use std::fs;
+    use std::path::Path;
     use std::str;
     use warp::http::header::HeaderMap;
 
@@ -755,7 +756,7 @@ mod tests {
 
     #[ctor::ctor]
     fn init() {
-        env::set_var("PYRSIA_ARTIFACT_PATH", "pyrsia-manifest-test");
+        env::set_var("PYRSIA_ARTIFACT_PATH", "pyrsia-test");
         env::set_var("DEV_MODE", "on");
     }
 
@@ -777,7 +778,6 @@ mod tests {
         check_put_manifest_result(result);
         check_artifact_manager_side_effects()?;
         check_package_version_metadata()?;
-        remove_dir_all(&env::var("PYRSIA_ARTIFACT_PATH").unwrap());
         Ok(())
     }
     #[test]
@@ -857,8 +857,10 @@ mod tests {
     }
 
     fn remove_dir_all(dir_name: &String) {
-        fs::remove_dir_all(dir_name.clone())
-            .expect(&format!("unable to remove test directory {}", dir_name));
+        if Path::new(dir_name).exists() {
+            fs::remove_dir_all(dir_name.clone())
+                .expect(&format!("unable to remove test directory {}", dir_name));
+        }
     }
 
     #[test]

--- a/src/docker/v2/handlers/manifests.rs
+++ b/src/docker/v2/handlers/manifests.rs
@@ -648,6 +648,8 @@ mod tests {
     use bytes::Bytes;
     use futures::executor;
     use serde::de::StdError;
+    use std::env;
+    use std::fs;
     use std::str;
     use warp::http::header::HeaderMap;
 
@@ -751,6 +753,12 @@ mod tests {
   ]
 }"##;
 
+    #[ctor::ctor]
+    fn init() {
+        env::set_var("PYRSIA_ARTIFACT_PATH", "pyrsia-manifest-test");
+        env::set_var("DEV_MODE", "on");
+    }
+
     #[test]
     fn test_handle_put_manifest_expecting_success_response_with_manifest_stored_in_artifact_manager_and_package_version_in_metadata_manager(
     ) -> Result<(), Box<dyn StdError>> {
@@ -769,6 +777,7 @@ mod tests {
         check_put_manifest_result(result);
         check_artifact_manager_side_effects()?;
         check_package_version_metadata()?;
+        remove_dir_all(&env::var("PYRSIA_ARTIFACT_PATH").unwrap());
         Ok(())
     }
     #[test]
@@ -793,6 +802,7 @@ mod tests {
             async { handle_get_manifests("hello-world".to_string(), "v3.1".to_string()).await };
         let result = executor::block_on(future);
         check_get_manifest_result(result);
+        remove_dir_all(&env::var("PYRSIA_ARTIFACT_PATH").unwrap());
         Ok(())
     }
 
@@ -844,6 +854,11 @@ mod tests {
         assert!(!manifest_content.is_empty());
         assert_eq!(4698, manifest_content.len());
         Ok(())
+    }
+
+    fn remove_dir_all(dir_name: &String) {
+        fs::remove_dir_all(dir_name.clone())
+            .expect(&format!("unable to remove test directory {}", dir_name));
     }
 
     #[test]

--- a/src/node_api/handlers/swarm.rs
+++ b/src/node_api/handlers/swarm.rs
@@ -65,7 +65,7 @@ pub async fn handle_get_status(
         }));
     }
 
-    let disk_space_result = disk_usage(ARTIFACTS_DIR);
+    let disk_space_result = disk_usage(ARTIFACTS_DIR.as_str());
     if disk_space_result.is_err() {
         return Err(warp::reject::custom(RegistryError {
             code: RegistryErrorCode::Unknown(disk_space_result.err().unwrap().to_string()),

--- a/src/node_manager/handlers.rs
+++ b/src/node_manager/handlers.rs
@@ -168,12 +168,6 @@ mod tests {
         0x4f,
     ];
 
-    #[ctor::ctor]
-    fn init() {
-        env::set_var("PYRSIA_ARTIFACT_PATH", "pyrsia-test");
-        env::set_var("DEV_MODE", "on");
-    }
-
     #[test]
     fn put_and_get_artifact_test() -> Result<(), anyhow::Error> {
         debug!("put_and_get_artifact_test started !!");
@@ -199,7 +193,7 @@ mod tests {
         };
         assert_eq!(s, s1);
 
-        remove_dir_all(&env::var("PYRSIA_ARTIFACT_PATH").unwrap());
+        //remove_dir_all(&env::var("PYRSIA_ARTIFACT_PATH").unwrap());
         Ok(())
     }
 
@@ -275,10 +269,5 @@ mod tests {
 
         assert_eq!(push_result, true);
         Ok(())
-    }
-
-    fn remove_dir_all(dir_name: &String) {
-        fs::remove_dir_all(dir_name.clone())
-            .expect(&format!("unable to remove test directory {}", dir_name));
     }
 }

--- a/src/node_manager/handlers.rs
+++ b/src/node_manager/handlers.rs
@@ -15,18 +15,17 @@
 */
 
 use super::ArtifactManager;
-use super::HashAlgorithm;
-
 use super::Hash;
+use super::HashAlgorithm;
 
 use crate::metadata_manager::metadata::Metadata;
 use crate::network::kademlia_thread_safe_proxy::KademliaThreadSafeProxy;
+use crate::util::env_util::*;
 use anyhow::{Context, Result};
 use byte_unit::Byte;
 use lazy_static::lazy_static;
 use libp2p::{identity, kad::record::store::MemoryStore, PeerId};
 use log::{debug, error, info};
-use std::env;
 use std::fs::File;
 use std::io::{BufReader, Read};
 use std::panic::UnwindSafe;
@@ -43,10 +42,10 @@ lazy_static! {
     pub static ref KADEMLIA_PROXY: KademliaThreadSafeProxy = KademliaThreadSafeProxy::default();
     pub static ref ARTIFACTS_DIR: String = log_static_initialization_failure(
         "Pyrsia Artifact directory",
-        env::var("PYRSIA_ARTIFACT_PATH").with_context(|| "Pyrsia artifact directory not set")
+        Ok(read_var("PYRSIA_ARTIFACT_PATH", "pyrsia"))
     );
     pub static ref ART_MGR: ArtifactManager = {
-        let dev_mode = env::var("DEV_MODE").unwrap_or_else(|_| "off".to_string());
+        let dev_mode = read_var("DEV_MODE", "off");
         if dev_mode.to_lowercase() == "on" {
             log_static_initialization_failure(
                 "Artifact Manager Directory",
@@ -157,6 +156,7 @@ mod tests {
     use super::*;
     use anyhow::Context;
     use assay::assay;
+    use std::env;
     use std::fs::File;
     use std::path::Path;
     use std::path::PathBuf;

--- a/src/util.rs
+++ b/src/util.rs
@@ -14,21 +14,4 @@
    limitations under the License.
 */
 
-#![allow(mixed_script_confusables)] // This is to allow structs created by a derive macro to have private fields that begin with the grek letter π
-
-extern crate lazy_static; // Must be done in crate root
-
-pub mod artifact_manager;
-pub mod docker;
-pub mod document_store;
-pub mod metadata_manager;
-pub mod network;
-pub mod node_api;
-pub mod node_manager;
-pub use node_manager::model; // Expose nested module at the crate level
-pub mod logging;
-pub mod util;
-
-// re-expose nested crates that need to be used together
-pub use signed;
-pub use signed_struct;
+pub mod env_util;

--- a/src/util/env_util.rs
+++ b/src/util/env_util.rs
@@ -20,7 +20,7 @@ pub fn read_var(variable_name: &str, default_value: &str) -> String {
     match env::var(variable_name) {
         Ok(v) => {
             let tr = v.trim();
-            if tr.len() > 0 {
+            if !tr.is_empty() {
                 String::from(tr)
             } else {
                 String::from(default_value)

--- a/src/util/env_util.rs
+++ b/src/util/env_util.rs
@@ -1,0 +1,70 @@
+/*
+   Copyright 2021 JFrog Ltd
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+use std::env;
+
+pub fn read_var(variable_name: &str, default_value: &str) -> String {
+    match env::var(variable_name) {
+        Ok(v) => {
+            let tr = v.trim();
+            if tr.len() > 0 {
+                String::from(tr)
+            } else {
+                String::from(default_value)
+            }
+        }
+        Err(_err) => String::from(default_value),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assay::assay;
+
+    #[test]
+    #[assay(
+        env = [
+          ("DEV_MODE", "on")
+        ],)]
+    fn test_value_present() {
+        assert_eq!("on", read_var("DEV_MODE", "off"));
+    }
+
+    #[test]
+    #[assay(
+        env = [
+          ("DEV_MODE", "on ")
+        ],)]
+    fn test_value_present_trim() {
+        assert_eq!("on", read_var("DEV_MODE", "off"));
+    }
+
+    #[test]
+    #[assay(
+        env = [
+            ("DEV_MODE", "")
+        ],)]
+    fn test_value_empty() {
+        assert_eq!("off", read_var("DEV_MODE", "off"));
+    }
+
+    #[test]
+    #[assay]
+    fn test_value_absent() {
+        assert_eq!("absent", read_var("DEV_MODE", "absent"));
+    }
+}


### PR DESCRIPTION
This PR closes #302 

1) Replaced ART_MGR_DIR hardcoded path to get from env variable
2) Introduced DEV_MODE env var for development and testing which will create PYRSIA_ARTIFACT_PATH
3) Fixed tests based on above changes
4) Updated readme and dockerfile to include above env vars.