### PR TITLE
Utilize `cargo check` to verify and better parallelize jobs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,40 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  check-workspace:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+    - run: cargo check --workspace --verbose  --release
+
+  check-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+    - run: cargo check --tests --verbose
+
   build:
+    needs: [check-workspace, check-tests]
     runs-on: ${{ matrix.os }}
     strategy:
         matrix:
@@ -86,7 +119,7 @@ jobs:
         github_repository: pyrsia/pyrsia.github.io
     
   coverage:
-    needs: [build]
+    needs: [check-tests]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
<!--

Thank you for participating with our effort to build a more secure software supply chain.
Before submitting your Pull Request please check the following.

-->

## PR Checklist

<!--

Locally run the build process

-->
- [x] I've built the code `cargo build`. For major changes, `cargo build --workspace --release` is recommended.
- [x] I've run the automated unit tests `cargo test`. This executes our automated unit tests.
- [x] I've not broken any existing tests or functionality. In addition to `cargo test`, I've run `cargo clippy`
- [x] I've not introduced any new known security vulnerabilities. I've run `cargo audit`

<!--

Make certain your Pull Request has the following.

-->
- [x] I've included a brief description and a good title of the proposed changes and how to test them.
- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've associated an [issue](https://github.com/pyrsia/pyrsia/issues) with this Pull Request. 
- [x] I've checked that the code is up-to-date with the `pyrsia/main` branch.
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/good_pr.md)
- [x] I've assigned this Pull Request to "pyrsia/collaborators"

## Description

Fixes #34 

Two new checks:
- "workspace" which in cargo means bin, libs, etc...
- "tests" which are the tests


Coverage only waits for checks.

This also has the added advantage of actually using the cache! 😆 

## Screenshots (optional)

### Before 

![image](https://user-images.githubusercontent.com/16867443/155411253-3c21057f-29db-4ee7-89a4-9b4a3ba3e7dc.png)

### After 

![image](https://user-images.githubusercontent.com/16867443/155411395-27722dd6-ad6f-4adc-aef5-d1c29b941315.png)


