### PR TITLE
Bump assay crate for security fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,14 +113,14 @@ checksum = "e22d1f4b888c298a027c99dc9048015fac177587de20fc30232a057dfbe24a21"
 
 [[package]]
 name = "assay"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238d82aacd5cfde8ccae5c981912be68ec3cfa2d92ff4ce34090be40584c96a6"
+checksum = "8b6400785ccafeab7f18a4d23d726f9090dd1195386f06026c6e59db36e11938"
 dependencies = [
  "assay-proc-macro",
  "pretty_assertions",
  "rusty-fork",
- "tempdir",
+ "tempfile",
  "tokio",
 ]
 
@@ -3383,19 +3383,6 @@ checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
@@ -3501,15 +3488,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
  "rand_core 0.6.3",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -4200,16 +4178,6 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
-]
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ features = []
 string_manipulation = {path="tests/string_manipulation"}
 expectest = "0.10.0"
 tokio-test = "0.4.2"
-assay = "0.1.0"
+assay = "0.1.1"
 
 [workspace]
 members = [


### PR DESCRIPTION
<!--

Thank you for participating with our effort to build a more secure software supply chain.
Before submitting your Pull Request please check the following.

-->

## PR Checklist

<!--

Locally run the build process

-->
- [x] I've built the code `cargo build`. For major changes, `cargo build --workspace --release` is recommended.
- [x] I've run the automated unit tests `cargo test`. This executes our automated unit tests.
- [x] I've not broken any existing tests or functionality. In addition to `cargo test`, I've run `cargo clippy`
- [x] I've not introduced any new known security vulnerabilities. I've run `cargo audit`

<!--

Make certain your Pull Request has the following.

-->
- [x] I've included a brief description and a good title of the proposed changes and how to test them.
- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've associated an [issue](https://github.com/pyrsia/pyrsia/issues) with this Pull Request. 
- [x] I've checked that the code is up-to-date with the `pyrsia/main` branch.
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/good_pr.md)
- [x] I've assigned this Pull Request to "pyrsia/collaborators"

## Description

Fixes #397

This PR fixes the security warning generated due to "assay" crate  using deprecated "tempdir" crate. Since i had raised PR with assay (https://github.com/mgattozzi/assay/pull/6) with updated codebase using "tempfile"and it got released so we can upgrade

## Screenshots (optional)
