### PR TITLE
Disable project board automation jobs on forks

### DIFF
--- a/.github/workflows/board-automation.yml
+++ b/.github/workflows/board-automation.yml
@@ -10,6 +10,7 @@ jobs:
   triage-new-issues:
     runs-on: ubuntu-latest
     if: |
+      github.repository_owner == 'pyrsia'
       github.event_name == 'issues' &&
       (github.event.action == 'opened' || github.event.action == 'reopened')
     steps:
@@ -26,6 +27,7 @@ jobs:
   in-progress-new-prs:
     runs-on: ubuntu-latest
     if: |
+      github.repository_owner == 'pyrsia'
       github.event_name == 'pull_request_target' &&
       (github.event.action == 'opened' || github.event.action == 'reopened')
     steps:
@@ -48,7 +50,9 @@ jobs:
     
   darfting-pr:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request_target' && github.event.action == 'converted_to_draft'
+    if: |
+      github.repository_owner == 'pyrsia'
+      github.event_name == 'pull_request_target' && github.event.action == 'converted_to_draft'
     steps:
       - uses: alex-page/github-project-automation-plus@v0.8.1
         with:
@@ -59,6 +63,7 @@ jobs:
   pr-request-review:
     runs-on: ubuntu-latest
     if: |
+      github.repository_owner == 'pyrsia'
       github.event_name == 'pull_request_target' &&
       (github.event.action == 'ready_for_review' || github.event.action == 'review_requested')
     steps:
@@ -71,6 +76,7 @@ jobs:
   label-blocked:
     runs-on: ubuntu-latest
     if: |
+      github.repository_owner == 'pyrsia'
       (github.event_name == 'issues' ||  github.event_name == 'pull_request_target') &&
       github.event.action == 'labeled' && github.event.label.name == 'blocked'
     steps:
@@ -83,6 +89,7 @@ jobs:
   assign-author:
     runs-on: ubuntu-latest
     if: |
+      github.repository_owner == 'pyrsia'
       github.event_name == 'pull_request_target' &&
       (github.event.action == 'opened'  || github.event.action == 'reopened' || github.event.action == 'ready_for_review')
     steps:


### PR DESCRIPTION
I got reports of random failure... this is what we did for the other workflows so I applied it here as well


