### PR TITLE
Use sccache for faster builds and split os/x and linux into separate jobs

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# We need to run both the workspace and test build at the same time in
+# the same GitHub action step.  This is done so the cache can be shared.
+#
+# GitHub action steps run serially and have a shared cache.  The GitHub
+# action jobs can run in parallel but do not share the same cache.
+#
+# The workaround is to run the builds as background processes and wait
+# for them to finish before exiting the script.
+
+# Need to save the return codes from the background processes to exit the
+# script with a bad return code if either fails
+
+set -x
+$( cargo build --workspace --verbose --release; echo $? > /tmp/ws.rc ) &
+$( cargo build --tests --verbose --release 1>/tmp/tests.log 2>&1; echo $? > /tmp/tests.rc ) &
+jobs
+wait
+
+# The workspace build is outputing as it runs so we just need to
+# output the test build once they are both done running
+echo cargo build --tests --verbose --release
+cat /tmp/tests.log
+
+# return the max return code between the two processes
+rc=$(cat /tmp/ws.rc /tmp/tests.rc | sort -nr | head -n1)
+exit $rc

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -14,6 +14,10 @@
 
 set -e
 
+# We need to split out build commands into separate calls in order to run them in parallel
+# therefore we cannot use --all-targets since that is equivalent to --lib --bins --tests --benches --examples
+# which disables the parallelizm we are trying achive for speed.
+
 $( cargo build --workspace --verbose --release; echo $? > /tmp/ws.rc ) &
 $( cargo build --tests --verbose --release 1>/tmp/tests.log 2>&1; echo $? > /tmp/tests.rc ) &
 jobs

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -12,17 +12,28 @@
 # Need to save the return codes from the background processes to exit the
 # script with a bad return code if either fails
 
-set -x
+set -e
+
 $( cargo build --workspace --verbose --release; echo $? > /tmp/ws.rc ) &
 $( cargo build --tests --verbose --release 1>/tmp/tests.log 2>&1; echo $? > /tmp/tests.rc ) &
 jobs
 wait
+
+# Display the workspace return code
+echo "### Workspace Build RC=$(cat /tmp/ws.rc)"
 
 # The workspace build is outputing as it runs so we just need to
 # output the test build once they are both done running
 echo cargo build --tests --verbose --release
 cat /tmp/tests.log
 
-# return the max return code between the two processes
+# Display the tests return code
+echo "### Tests Build RC=$(cat /tmp/tests.rc)"
+
+# Return the max return code between the two processes.
+# This is done to tell the GitHub Step to fail (rc != 0). The 
+# value of the rc is not important at this point since each
+# build has already displayed its return code. 
+
 rc=$(cat /tmp/ws.rc /tmp/tests.rc | sort -nr | head -n1)
 exit $rc

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,8 +44,7 @@ jobs:
         .github/workflows/build.sh 
         sccache --show-stats
 
-  # Linux Build Job with .deb creation and upload
-  build:
+  build-push-linux:
     runs-on: ubuntu-latest
     env:
       RUSTC_WRAPPER: /home/runner/.cargo/bin/sccache

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -142,7 +142,7 @@ jobs:
   # Docker build that uses the published .deb file from the Linux build
   docker:
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [build-push-linux]
     if: github.repository_owner == 'pyrsia' && github.event_name == 'push'
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -107,7 +107,7 @@ jobs:
         repo_supported_arch: |
           amd64
         page_branch: gh-pages
-        file: /github/workspace/$PWD/target/debian/pyrsia_0.1.0+${{ github.run_number }}_amd64.deb
+        file: /github/workspace/target/debian/pyrsia_0.1.0+${{ github.run_number }}_amd64.deb
         file_target_version: focal
         public_key: ${{ secrets.GPG_PUBLIC }}
         private_key: ${{ secrets.GPG_PRIVATE }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,7 +39,7 @@ jobs:
       run: |
         sed -i.bak "/^version = \"0.1.0\"/s/\"\$/+${{ github.run_number }}\"/" Cargo.toml
 
-    - name: Build and Test Release Binaries
+    - name: Build Release and Test Binaries
       run: |
         .github/workflows/build.sh 
         sccache --show-stats
@@ -81,7 +81,7 @@ jobs:
         sed -i.bak "/^version = \"0.1.0\"/s/\"\$/+${{ github.run_number }}\"/" Cargo.toml
 
     # Run cargo build in parallel using sscache to avoid OS locking errors
-    - name: Build and Test Release Binaries
+    - name: Build Release and Test Binaries
       run: |
         .github/workflows/build.sh
         sccache --show-stats 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,64 +9,64 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  check-workspace:
-    runs-on: ubuntu-latest
+  # OS/X  Build Job 
+  build-osx:
+    runs-on: macos-latest
+    env: 
+      RUSTC_WRAPPER: /Users/runner/.cargo/bin/sccache
+      CARGO_INCREMENTAL: 0   
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/cache@v3
+  
+    # Use sscache store in GitHub cache
+    - uses: actions/cache@v2
       with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
+        path: /Users/runner/Library/Caches/Mozilla.sccache
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-    - run: cargo check --workspace --verbose --release
-
-  check-tests:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-    - run: cargo check --tests --verbose
-
-  build:
-    needs: [check-workspace, check-tests]
-    runs-on: ${{ matrix.os }}
-    strategy:
-        matrix:
-            os: [macos-latest, ubuntu-latest]
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    # Install sccache from binary
+    - run: |
+        .github/workflows/sccache-macos.sh
+        sccache --start-server
+        sccache --show-stats
 
     - name: Install openssl on macOS
-      if: runner.os == 'macOS'
       run: |
         brew install openssl
 
+    # Need to add build number to version number
+    - name: Add Build to Version Number
+      run: |
+        sed -i.bak "/^version = \"0.1.0\"/s/\"\$/+${{ github.run_number }}\"/" Cargo.toml
+
+    - name: Build and Test Release Binaries
+      run: |
+        .github/workflows/build.sh 
+        sccache --show-stats
+
+  # Linux Build Job with .deb creation and upload
+  build:
+    runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: /home/runner/.cargo/bin/sccache
+      CARGO_INCREMENTAL: 0      
+    steps:
+    - uses: actions/checkout@v3
+
+    # Use sscache store in GitHub cache
+    - uses: actions/cache@v2
+      with:
+        path: /home/runner/.cache/sccache
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+    # Install sccache from binary
+    - run: |
+        .github/workflows/sccache-linux.sh
+        sccache --start-server
+        sccache --show-stats
+
     # Install cargo deb and strip
     - name: Install cargo-deb cargo-strip
-      if: runner.os == 'Linux'
       uses: actions-rs/cargo@v1.0.3
       with:
         command: install
@@ -77,22 +77,19 @@ jobs:
       run: |
         sed -i.bak "/^version = \"0.1.0\"/s/\"\$/+${{ github.run_number }}\"/" Cargo.toml
 
-    - name: Build Release Binaries
+    # Run cargo build in parallel using sscache to avoid OS locking errors
+    - name: Build and Test Release Binaries
       run: |
-        cargo build --workspace --verbose --all-targets --release
+        .github/workflows/build.sh
+        sccache --show-stats 
 
-    - name: Execute Test Cases
-      run: |
-        cargo test --workspace --verbose
-
+    # Strip binaries 
     - name: Strip Binaries
-      if: runner.os == 'Linux'
       run: |
         cargo strip
 
     # Create Pyrsia .deb file
     - name: Package Pyrsia as deb file
-      if: runner.os == 'Linux'
       uses: actions-rs/cargo@v1.0.3
       with:
         command: deb
@@ -103,7 +100,7 @@ jobs:
     - name: Upload Pyrsia .deb to website repo
       uses: sbtaylor15/apt-repo-action@v2.0.4
       # Only when we push on the main repository should we upload the results
-      if: github.repository_owner == 'pyrsia' && github.event_name == 'push' && runner.os == 'Linux'
+      if: github.repository_owner == 'pyrsia' && github.event_name == 'push'
       with:
         github_token: ${{ secrets.APT }}
         repo_supported_version: |
@@ -111,29 +108,20 @@ jobs:
         repo_supported_arch: |
           amd64
         page_branch: gh-pages
-        file: /github/workspace/target/debian/pyrsia_0.1.0+${{ github.run_number }}_amd64.deb
+        file: /github/workspace/$PWD/target/debian/pyrsia_0.1.0+${{ github.run_number }}_amd64.deb
         file_target_version: focal
         public_key: ${{ secrets.GPG_PUBLIC }}
         private_key: ${{ secrets.GPG_PRIVATE }}
         key_passphrase: ${{ secrets.GPG_SECRET }}
         github_repository: pyrsia/pyrsia.github.io
-
+  
+  # Coverage wipes the cache in order to instrument the code.  No need to wait for other jobs to run it.
   coverage:
-    needs: [check-tests]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Install stable toolchain
       uses: actions-rs/toolchain@v1
@@ -151,7 +139,8 @@ jobs:
       with:
         token: ${{secrets.CODECOV_TOKEN}}
         fail_ci_if_error: ${{ github.repository_owner == 'pyrsia' }}
-
+  
+  # Docker build that uses the published .deb file from the Linux build
   docker:
     runs-on: ubuntu-latest
     needs: [build]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,6 +44,10 @@ jobs:
         .github/workflows/build.sh 
         sccache --show-stats
 
+    - name: Execute Test Cases
+      run: |
+        cargo test --workspace --verbose
+
   build-push-linux:
     runs-on: ubuntu-latest
     env:
@@ -81,6 +85,10 @@ jobs:
       run: |
         .github/workflows/build.sh
         sccache --show-stats 
+
+    - name: Execute Test Cases
+      run: |
+        cargo test --workspace --verbose
 
     # Strip binaries 
     - name: Strip Binaries

--- a/.github/workflows/sccache-linux.sh
+++ b/.github/workflows/sccache-linux.sh
@@ -2,6 +2,5 @@
 
 # Download and install sccache in the Linux specific cargo directories
 mkdir -p /home/runner/.cargo/bin 2>/dev/null
-curl -o- -sSLf https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz | tar xzf -
-mv sccache-v0.2.15-x86_64-unknown-linux-musl/sccache /home/runner/.cargo/bin/sccache 
+curl -o- -sSLf https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz | tar --strip-components=1 -C /home/runner/.cargo/bin -xzf -
 chmod 755 /home/runner/.cargo/bin/sccache

--- a/.github/workflows/sccache-linux.sh
+++ b/.github/workflows/sccache-linux.sh
@@ -2,6 +2,6 @@
 
 set -e
 # Download and install sccache in the Linux specific cargo directories
-test -f  /home/runner/.cargo/bin || mkdir -p /home/runner/.cargo/bin 2>/dev/null
+mkdir -p /home/runner/.cargo/bin
 curl -o- -sSLf https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz | tar --strip-components=1 -C /home/runner/.cargo/bin -xzf -
 chmod 755 /home/runner/.cargo/bin/sccache

--- a/.github/workflows/sccache-linux.sh
+++ b/.github/workflows/sccache-linux.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Download and install sccache in the Linux specific cargo directories
+mkdir -p /home/runner/.cargo/bin 2>/dev/null
+curl -o- -sSLf https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz | tar xzf -
+mv sccache-v0.2.15-x86_64-unknown-linux-musl/sccache /home/runner/.cargo/bin/sccache 
+chmod 755 /home/runner/.cargo/bin/sccache

--- a/.github/workflows/sccache-linux.sh
+++ b/.github/workflows/sccache-linux.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
 # Download and install sccache in the Linux specific cargo directories
-mkdir -p /home/runner/.cargo/bin 2>/dev/null
+test -f  /home/runner/.cargo/bin || mkdir -p /home/runner/.cargo/bin 2>/dev/null
 curl -o- -sSLf https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz | tar --strip-components=1 -C /home/runner/.cargo/bin -xzf -
 chmod 755 /home/runner/.cargo/bin/sccache

--- a/.github/workflows/sccache-macos.sh
+++ b/.github/workflows/sccache-macos.sh
@@ -2,6 +2,6 @@
 
 set -e
 # Download and install sccache in the OS/X specific cargo directories
-test -f /Users/runner/.cargo/bin || mkdir -p /Users/runner/.cargo/bin 
+mkdir -p /Users/runner/.cargo/bin 
 curl -o- -sSLf https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-apple-darwin.tar.gz | tar --strip-components=1 -C /Users/runner/.cargo/bin -xzf -
 chmod 755 /Users/runner/.cargo/bin/sccache

--- a/.github/workflows/sccache-macos.sh
+++ b/.github/workflows/sccache-macos.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
 # Download and install sccache in the OS/X specific cargo directories
-mkdir -p /Users/runner/.cargo/bin 2>/dev/null
+test -f /Users/runner/.cargo/bin || mkdir -p /Users/runner/.cargo/bin 
 curl -o- -sSLf https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-apple-darwin.tar.gz | tar --strip-components=1 -C /Users/runner/.cargo/bin -xzf -
 chmod 755 /Users/runner/.cargo/bin/sccache

--- a/.github/workflows/sccache-macos.sh
+++ b/.github/workflows/sccache-macos.sh
@@ -2,6 +2,5 @@
 
 # Download and install sccache in the OS/X specific cargo directories
 mkdir -p /Users/runner/.cargo/bin 2>/dev/null
-curl -o- -sSLf https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-apple-darwin.tar.gz | tar xzf -
-mv sccache-v0.2.15-x86_64-apple-darwin/sccache /Users/runner/.cargo/bin/sccache 
+curl -o- -sSLf https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-apple-darwin.tar.gz | tar --strip-components=1 -C /Users/runner/.cargo/bin -xzf -
 chmod 755 /Users/runner/.cargo/bin/sccache

--- a/.github/workflows/sccache-macos.sh
+++ b/.github/workflows/sccache-macos.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Download and install sccache in the OS/X specific cargo directories
+mkdir -p /Users/runner/.cargo/bin 2>/dev/null
+curl -o- -sSLf https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-apple-darwin.tar.gz | tar xzf -
+mv sccache-v0.2.15-x86_64-apple-darwin/sccache /Users/runner/.cargo/bin/sccache 
+chmod 755 /Users/runner/.cargo/bin/sccache

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3400,7 +3400,7 @@ dependencies = [
 
 [[package]]
 name = "pyrsia"
-version = "0.1.1"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "assay",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3400,7 +3400,7 @@ dependencies = [
 
 [[package]]
 name = "pyrsia"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "assay",


### PR DESCRIPTION
## PR Checklist

- [X] I've built the code `cargo build`. For major changes, `cargo build --workspace --release` is recommended.
- [X] I've run the automated unit tests `cargo test`. This executes our automated unit tests.
- [X] I've not broken any existing tests or functionality. In addition to `cargo test`, I've run `cargo clippy`
- [X] I've not introduced any new known security vulnerabilities. I've run `cargo audit`

<!--

Make certain your Pull Request has the following.

-->
- [x] I've included a brief description and a good title of the proposed changes and how to test them.
- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've associated an [issue](https://github.com/pyrsia/pyrsia/issues) with this Pull Request. 
- [x] I've checked that the code is up-to-date with the `pyrsia/main` branch.
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/good_pr.md)
- [x] I've assigned this Pull Request to "pyrsia/collaborators"

## Description

Fixes pyrsia/pyrsia#389

Implemented sccache to speed up builds.  This is done by removing the `cargo check` commands and consolidating the `cargo build --workspace` and `cargo build --tests` into a script that will run both commands at the same time in the background utilizing sccache.  

Moved the scripting from the rust.yaml to .sh files in order to keep the rust.yaml readable.  

The initial run with fresh empty cache is ~25mins and from an existing cache ~10-15mins.  Cache is recreated when the md5 of the Cargo.lock changes.


## Screenshots (optional)

![image](https://user-images.githubusercontent.com/14826572/156423674-f079108b-98ab-4373-a920-05153588bde3.png)
