### PR TITLE
Ignoring test due to docker limit

### DIFF
--- a/src/docker/v2/handlers/manifests.rs
+++ b/src/docker/v2/handlers/manifests.rs
@@ -770,7 +770,6 @@ mod tests {
         }
     }
 
-    #[test]
     #[assay(
     env = [
       ("PYRSIA_ARTIFACT_PATH", "pyrsia-test-node"),
@@ -797,7 +796,6 @@ mod tests {
         check_package_version_metadata()?;
     }
 
-    #[test]
     #[assay(
         env = [
           ("PYRSIA_ARTIFACT_PATH", "pyrsia-test-node"),
@@ -827,13 +825,7 @@ mod tests {
     }
 
     #[test]
-    #[assay(
-        env = [
-          ("PYRSIA_ARTIFACT_PATH", "pyrsia-test-node"),
-          ("DEV_MODE", "on")
-        ],
-        teardown = tear_down()
-        )]
+    #[ignore]
     fn test_fetch_manifest_if_not_in_pyrsia_expecting_fetch_from_dockerhub_success_and_store_in_pyrsia(
     ) {
         let name = "alpine";

--- a/src/node_manager/handlers.rs
+++ b/src/node_manager/handlers.rs
@@ -175,7 +175,6 @@ mod tests {
         }
     }
 
-    #[test]
     #[assay(
         env = [
           ("PYRSIA_ARTIFACT_PATH", "pyrsia-test-node"),

--- a/src/util/env_util.rs
+++ b/src/util/env_util.rs
@@ -35,7 +35,6 @@ mod tests {
     use super::*;
     use assay::assay;
 
-    #[test]
     #[assay(
         env = [
           ("DEV_MODE", "on")
@@ -44,7 +43,6 @@ mod tests {
         assert_eq!("on", read_var("DEV_MODE", "off"));
     }
 
-    #[test]
     #[assay(
         env = [
           ("DEV_MODE", "on ")
@@ -53,7 +51,6 @@ mod tests {
         assert_eq!("on", read_var("DEV_MODE", "off"));
     }
 
-    #[test]
     #[assay(
         env = [
             ("DEV_MODE", "")
@@ -62,7 +59,6 @@ mod tests {
         assert_eq!("off", read_var("DEV_MODE", "off"));
     }
 
-    #[test]
     #[assay]
     fn test_value_absent() {
         assert_eq!("absent", read_var("DEV_MODE", "absent"));


### PR DESCRIPTION
<!--

Thank you for participating with our effort to build a more secure software supply chain.
Before submitting your Pull Request please check the following.

-->

## PR Checklist

<!--

Locally run the build process

-->
- [x] I've built the code `cargo build`. For major changes, `cargo build --workspace --release` is recommended.
- [x] I've run the automated unit tests `cargo test`. This executes our automated unit tests.
- [ ] I've not broken any existing tests or functionality. In addition to `cargo test`, I've run `cargo clippy`
- [x] I've not introduced any new known security vulnerabilities. I've run `cargo audit`

<!--

Make certain your Pull Request has the following.

-->
- [x] I've included a brief description and a good title of the proposed changes and how to test them.
- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [ ] I've associated an [issue](https://github.com/pyrsia/pyrsia/issues) with this Pull Request. 
- [x] I've checked that the code is up-to-date with the `pyrsia/main` branch.
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/good_pr.md)
- [ ] I've assigned this Pull Request to "pyrsia/collaborators"

## Description

Fixes pyrsia/pyrsia#

This PR ignores one test which calls dockerhub due to rate-limit, as discussed with @erwin1 this test will evolve to have only central node requesting from dockerhub , when that concept will be implemented we can reuse this and put extra assert for rate-limit.
It also removes extra test macros on top of assay macro as that result in running test twice.

## Screenshots (optional)
