### PR TITLE
Fix warning in blockchain identities

### DIFF
--- a/src/blockchain/src/identities/verify_key.rs
+++ b/src/blockchain/src/identities/verify_key.rs
@@ -34,7 +34,7 @@ impl VerifyKey {
 
 impl Encode for VerifyKey {
     fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
-        self.public.encode().using_encoded(f)
+        self.public().encode().using_encoded(f)
     }
 
     fn size_hint(&self) -> usize {


### PR DESCRIPTION
<!--

Thank you for participating with our effort to build a more secure software supply chain.
Before submitting your Pull Request please check the following.

-->

## PR Checklist

<!--

Locally run the build process

-->
- [x] I've built the code `cargo build`. For major changes, `cargo build --workspace --release` is recommended.
- [x] I've run the automated unit tests `cargo test`. This executes our automated unit tests.
- [x] I've not broken any existing tests or functionality. In addition to `cargo test`, I've run `cargo clippy`
- [x] I've not introduced any new known security vulnerabilities. I've run `cargo audit`

<!--

Make certain your Pull Request has the following.

-->
- [x] I've included a brief description and a good title of the proposed changes and how to test them.
- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've associated an [issue](https://github.com/pyrsia/pyrsia/issues) with this Pull Request. 
- [x] I've checked that the code is up-to-date with the `pyrsia/main` branch.
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/good_pr.md)
- [x] I've assigned this Pull Request to "pyrsia/collaborators"

## Description

This PR fixes the following warning by using the `public` function.
```
warning: associated function is never used: `public`
  --> src/blockchain/src/identities/verify_key.rs:30:12
   |
30 |     pub fn public(&self) -> PublicKey {
   |            ^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default
```

## Screenshots (optional)
