### PR TITLE
Introduce the `KeyBox` for consensus engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4093,6 +4093,7 @@ version = "0.1.0"
 dependencies = [
  "aleph-bft",
  "anyhow",
+ "async-trait",
  "bincode",
  "ed25519-dalek",
  "futures",

--- a/src/blockchain/Cargo.toml
+++ b/src/blockchain/Cargo.toml
@@ -20,6 +20,7 @@ anyhow = "1.0.55"
 aleph-bft = "0.8.4"
 codec = {package = "parity-scale-codec", version = "2.3.1", default-features = false, features = ["derive"]}
 hex = "0.4.3"
+async-trait = "0.1.52"
 
 [[example]]
 name = "simple_node"

--- a/src/blockchain/src/identities.rs
+++ b/src/blockchain/src/identities.rs
@@ -16,5 +16,6 @@
 
 pub mod authority_pen;
 pub mod authority_verifier;
+pub mod key_box;
 pub mod verify_key;
 use super::signature;

--- a/src/blockchain/src/identities/authority_pen.rs
+++ b/src/blockchain/src/identities/authority_pen.rs
@@ -14,25 +14,27 @@
    limitations under the License.
 */
 
-// TODO(prince-chrismc): Re-introduce `NodeIndex` to associate with `PeerId` when adding `KeyBox`
-// use aleph_bft::NodeIndex;
-use libp2p::core::identity::ed25519::Keypair;
+use aleph_bft::NodeIndex;
+use libp2p::core::identity::ed25519::{Keypair, PublicKey};
 
 use super::signature::Signature;
 
 #[derive(Clone)]
 pub struct AuthorityPen {
-    // index: NodeIndex,
+    index: NodeIndex,
     keypair: Keypair,
 }
 
 impl AuthorityPen {
-    pub fn new(/*index: NodeIndex,*/ keypair: Keypair) -> Self {
-        Self {
-            /*index,*/ keypair,
-        }
+    pub fn new(index: NodeIndex, keypair: Keypair) -> Self {
+        Self { index, keypair }
     }
-
+    pub fn index(&self) -> NodeIndex {
+        self.index
+    }
+    pub fn public(&self) -> PublicKey {
+        self.keypair.public()
+    }
     pub fn sign(&self, msg: &[u8]) -> Signature {
         Signature::new(msg, &self.keypair)
     }
@@ -45,7 +47,7 @@ mod tests {
     #[test]
     fn test_auth_pen_sign() {
         let keypair = Keypair::generate();
-        let auth_pen = AuthorityPen::new(keypair.clone());
+        let auth_pen = AuthorityPen::new(0.into(), keypair.clone());
         let signed = auth_pen.sign(b"hello world!");
 
         assert!(keypair.public().verify(b"hello world!", &signed.to_bytes()));

--- a/src/blockchain/src/identities/authority_verifier.rs
+++ b/src/blockchain/src/identities/authority_verifier.rs
@@ -24,7 +24,7 @@ use super::signature::{MultiSignature, Signature};
 #[derive(Clone, Default)]
 pub struct AuthorityVerifier {
     authorities: HashMap<NodeIndex, PublicKey>,
-    // TODO(prince-chrismc): Re-introduce `NodeIndex` to associate with `PeerId` when adding `KeyBox`
+    // TODO(prince-chrismc): Re-introduce `NodeIndex` to associate with `PeerId` when adding `network`
     // peers_by_index: HashMap<NodeIndex, PeerId>,
 }
 

--- a/src/blockchain/src/identities/key_box.rs
+++ b/src/blockchain/src/identities/key_box.rs
@@ -1,0 +1,111 @@
+/*
+   Copyright 2021 JFrog Ltd
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+use aleph_bft::{NodeCount, NodeIndex, PartialMultisignature};
+use async_trait::async_trait;
+use libp2p::core::identity::ed25519::PublicKey;
+use log::trace;
+
+use super::authority_pen::AuthorityPen;
+use super::authority_verifier::AuthorityVerifier;
+use super::signature::{MultiSignature, Signature};
+
+#[derive(Clone)]
+pub struct KeyBox {
+    authority_pen: AuthorityPen,
+    authority_verifier: AuthorityVerifier,
+}
+
+impl KeyBox {
+    pub fn new(authority_pen: AuthorityPen, authority_verifier: AuthorityVerifier) -> Self {
+        let mut kb = Self {
+            authority_pen,
+            authority_verifier,
+        };
+        // Record the pen as a known authority -- always trust yourself
+        kb.record_authority(kb.authority_pen.index(), kb.authority_pen.public());
+        kb
+    }
+    pub fn record_authority(&mut self, node_index: NodeIndex, public_key: PublicKey) {
+        self.authority_verifier.save(node_index, public_key);
+    }
+}
+
+#[async_trait]
+impl aleph_bft::KeyBox for KeyBox {
+    type Signature = Signature;
+
+    fn node_count(&self) -> NodeCount {
+        self.authority_verifier.node_count()
+    }
+
+    async fn sign(&self, msg: &[u8]) -> Self::Signature {
+        trace!("🖋️ {:?} signing message", self.authority_pen.index());
+        self.authority_pen.sign(msg)
+    }
+
+    fn verify(&self, msg: &[u8], sgn: &Self::Signature, index: NodeIndex) -> bool {
+        trace!(
+            "🔎 {:?} verifying message and signature from {:?}",
+            self.authority_pen.index(),
+            index
+        );
+        self.authority_verifier.verify(msg, sgn, index)
+    }
+}
+
+impl aleph_bft::MultiKeychain for KeyBox {
+    type PartialMultisignature = MultiSignature;
+
+    fn from_signature(
+        &self,
+        signature: &Signature,
+        index: NodeIndex,
+    ) -> Self::PartialMultisignature {
+        MultiSignature::add_signature(
+            MultiSignature::with_size(self.authority_verifier.node_count()),
+            signature,
+            index,
+        )
+    }
+    fn is_complete(&self, msg: &[u8], partial: &Self::PartialMultisignature) -> bool {
+        self.authority_verifier.is_complete(msg, partial)
+    }
+}
+
+impl aleph_bft::Index for KeyBox {
+    fn index(&self) -> NodeIndex {
+        self.authority_pen.index()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aleph_bft::KeyBox as AlephKeyBox;
+    use libp2p::core::identity::ed25519::Keypair;
+
+    #[tokio::test]
+    async fn test_key_box_self_signed() {
+        let key_box = KeyBox::new(
+            AuthorityPen::new(0.into(), Keypair::generate()),
+            AuthorityVerifier::new(),
+        );
+        let sign: Signature = key_box.sign(b"hello world!").await;
+
+        assert_eq!(key_box.verify(b"hello world", &sign, 0.into()), false);
+    }
+}


### PR DESCRIPTION
<!--

Thank you for participating with our effort to build a more secure software supply chain.
Before submitting your Pull Request please check the following.

-->

## PR Checklist

<!--

Locally run the build process

-->
- [x] I've built the code `cargo build`. For major changes, `cargo build --workspace --release` is recommended.
- [x] I've run the automated unit tests `cargo test`. This executes our automated unit tests.
- [x] I've not broken any existing tests or functionality. In addition to `cargo test`, I've run `cargo clippy`
- [x] I've not introduced any new known security vulnerabilities. I've run `cargo audit`

<!--

Make certain your Pull Request has the following.

-->
- [x] I've included a brief description and a good title of the proposed changes and how to test them.
- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've associated an [issue](https://github.com/pyrsia/pyrsia/issues) with this Pull Request. 
- [x] I've checked that the code is up-to-date with the `pyrsia/main` branch.
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/good_pr.md)
- [x] I've assigned this Pull Request to "pyrsia/collaborators"

## Description

Towards pyrsia/pyrsia#322

This PR add the `KeyBox` this is the main trait the Aleph needs to verify the signatories of blocks during consensus

https://docs.rs/aleph-bft/latest/aleph_bft/trait.KeyBox.html

> A typical implementation of `KeyBox` would be a collection of `N` public keys, an index `i` and a single private key corresponding to the public key number `i`