### PR TITLE
Provide and retrieve artifacts via the kademlia p2p network

### DIFF
--- a/pyrsia_node/src/main.rs
+++ b/pyrsia_node/src/main.rs
@@ -39,10 +39,9 @@ async fn main() {
 
     tokio::spawn(event_loop.run());
 
-    let final_peer_id = match args.peer {
-        Some(to_dial) => dial_other_peer(p2p_client.clone(), to_dial).await,
-        None => None,
-    };
+    if let Some(to_dial) = args.peer {
+        dial_other_peer(p2p_client.clone(), to_dial).await;
+    }
 
     // Listen on all interfaces and whatever port the OS assigns
     p2p_client
@@ -63,7 +62,7 @@ async fn main() {
         port.parse::<u16>().unwrap(),
     );
 
-    let docker_routes = make_docker_routes(p2p_client.clone(), final_peer_id);
+    let docker_routes = make_docker_routes(p2p_client.clone());
     let node_api_routes = make_node_routes(p2p_client.clone());
     let all_routes = docker_routes.or(node_api_routes);
 

--- a/src/docker/v2/handlers/blobs.rs
+++ b/src/docker/v2/handlers/blobs.rs
@@ -33,8 +33,7 @@ use uuid::Uuid;
 use warp::{http::StatusCode, Rejection, Reply};
 
 pub async fn handle_get_blobs(
-    p2p_client: p2p::Client,
-    peer_id: Option<PeerId>,
+    mut p2p_client: p2p::Client,
     name: String,
     hash: String,
 ) -> Result<impl Reply, Rejection> {
@@ -54,7 +53,7 @@ pub async fn handle_get_blobs(
                 hash
             );
 
-            let blob_stored = get_blob_from_network(p2p_client, peer_id, &name, &hash).await?;
+            let blob_stored = get_blob_from_network(p2p_client.clone(), &name, &hash).await?;
             if blob_stored {
                 blob_content =
                     get_artifact(&decoded_hash, HashAlgorithm::SHA256).map_err(|_| {
@@ -69,6 +68,8 @@ pub async fn handle_get_blobs(
             }
         }
     }
+
+    p2p_client.provide(String::from(&hash)).await;
 
     debug!("Final Step: {:?} successfully retrieved!", hash);
     Ok(warp::http::response::Builder::new()
@@ -216,12 +217,12 @@ fn store_blob_in_filesystem(
 
 // Request the content of the artifact from the pyrsia network
 async fn get_blob_from_network(
-    p2p_client: p2p::Client,
-    peer_id: Option<PeerId>,
+    mut p2p_client: p2p::Client,
     name: &str,
     hash: &str,
 ) -> Result<bool, Rejection> {
-    Ok(match peer_id {
+    let providers = p2p_client.list_providers(String::from(hash)).await;
+    Ok(match providers.iter().next() {
         Some(peer) => match get_blob_from_other_peer(p2p_client.clone(), peer, name, hash).await {
             true => true,
             false => get_blob_from_docker_hub(name, hash).await?,
@@ -233,7 +234,7 @@ async fn get_blob_from_network(
 // Request the content of the artifact from other peer
 async fn get_blob_from_other_peer(
     mut p2p_client: p2p::Client,
-    peer_id: PeerId,
+    peer_id: &PeerId,
     name: &str,
     hash: &str,
 ) -> bool {

--- a/src/docker/v2/routes.rs
+++ b/src/docker/v2/routes.rs
@@ -19,13 +19,11 @@ use crate::network::p2p;
 
 use super::handlers::blobs::*;
 use super::handlers::manifests::*;
-use libp2p::PeerId;
 use std::collections::HashMap;
 use warp::Filter;
 
 pub fn make_docker_routes(
     p2p_client: p2p::Client,
-    peer_id: Option<PeerId>,
 ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
     let empty_json = "{}";
     let v2_base = warp::path("v2")
@@ -56,7 +54,7 @@ pub fn make_docker_routes(
     let v2_blobs = warp::path!("v2" / "library" / String / "blobs" / String)
         .and(warp::get().or(warp::head()).unify())
         .and(warp::path::end())
-        .and_then(move |name, hash| handle_get_blobs(p2p_client.clone(), peer_id, name, hash));
+        .and_then(move |name, hash| handle_get_blobs(p2p_client.clone(), name, hash));
     let v2_blobs_post = warp::path!("v2" / "library" / String / "blobs" / "uploads")
         .and(warp::post())
         .and_then(handle_post_blob);

--- a/src/network/handlers.rs
+++ b/src/network/handlers.rs
@@ -24,7 +24,7 @@ use libp2p::Multiaddr;
 use log::{error, info};
 
 /// Reach out to another node with the specified address
-pub async fn dial_other_peer(mut p2p_client: p2p::Client, to_dial: Multiaddr) -> Option<PeerId> {
+pub async fn dial_other_peer(mut p2p_client: p2p::Client, to_dial: Multiaddr) {
     let peer_id = match to_dial.clone().pop() {
         Some(Protocol::P2p(hash)) => Ok(PeerId::from_multihash(hash).expect("Valid hash.")),
         _ => Err("Expect peer multiaddr to contain peer ID."),
@@ -36,11 +36,9 @@ pub async fn dial_other_peer(mut p2p_client: p2p::Client, to_dial: Multiaddr) ->
                 .await
                 .expect("Dial to succeed.");
             info!("Dialed {:?}", to_dial);
-            Some(peer_id)
         }
         Err(e) => {
             error!("Failed to dial peer: {}", e);
-            None
         }
     }
 }

--- a/src/network/handlers.rs
+++ b/src/network/handlers.rs
@@ -17,30 +17,17 @@
 use crate::artifacts_repository::hash_util::HashAlgorithm;
 use crate::network::p2p;
 use crate::node_manager::handlers::get_artifact;
-use libp2p::core::PeerId;
-use libp2p::multiaddr::Protocol;
 use libp2p::request_response::ResponseChannel;
 use libp2p::Multiaddr;
-use log::{error, info};
+use log::info;
 
 /// Reach out to another node with the specified address
 pub async fn dial_other_peer(mut p2p_client: p2p::Client, to_dial: Multiaddr) {
-    let peer_id = match to_dial.clone().pop() {
-        Some(Protocol::P2p(hash)) => Ok(PeerId::from_multihash(hash).expect("Valid hash.")),
-        _ => Err("Expect peer multiaddr to contain peer ID."),
-    };
-    match peer_id {
-        Ok(peer_id) => {
-            p2p_client
-                .dial(peer_id, to_dial.clone())
-                .await
-                .expect("Dial to succeed.");
-            info!("Dialed {:?}", to_dial);
-        }
-        Err(e) => {
-            error!("Failed to dial peer: {}", e);
-        }
-    }
+    p2p_client
+        .dial(to_dial.clone())
+        .await
+        .expect("Dial to succeed.");
+    info!("Dialed {:?}", to_dial);
 }
 
 /// Respond to a RequestArtifact event by getting the artifact from

--- a/src/network/p2p.rs
+++ b/src/network/p2p.rs
@@ -22,7 +22,9 @@ use libp2p::core::upgrade::{read_length_prefixed, write_length_prefixed, Protoco
 use libp2p::core::{Multiaddr, PeerId};
 use libp2p::identity;
 use libp2p::kad::record::store::MemoryStore;
-use libp2p::kad::{GetClosestPeersOk, Kademlia, KademliaEvent, QueryId, QueryResult};
+use libp2p::kad::{
+    GetClosestPeersOk, GetProvidersOk, Kademlia, KademliaEvent, QueryId, QueryResult,
+};
 use libp2p::multiaddr::Protocol;
 use libp2p::request_response::{
     ProtocolSupport, RequestId, RequestResponse, RequestResponseCodec, RequestResponseEvent,
@@ -32,7 +34,7 @@ use libp2p::swarm::{ConnectionHandlerUpgrErr, SwarmBuilder, SwarmEvent};
 use libp2p::{NetworkBehaviour, Swarm};
 use log::{debug, info, warn};
 use std::collections::hash_map::Entry::Vacant;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::fmt::{Display, Formatter};
 use std::io;
@@ -107,7 +109,7 @@ impl Client {
         receiver.await.expect("Sender not to be dropped.")
     }
 
-    pub async fn list_peers(&mut self) -> Vec<PeerId> {
+    pub async fn list_peers(&mut self) -> HashSet<PeerId> {
         let (sender, receiver) = oneshot::channel();
         self.sender
             .send(Command::ListPeers {
@@ -119,10 +121,21 @@ impl Client {
         receiver.await.expect("Sender not to be dropped.")
     }
 
-    pub async fn lookup_blob(&mut self, hash: String) -> Result<(), Box<dyn Error + Send>> {
+    pub async fn provide(&mut self, hash: String) {
+        debug!("p2p::Client::provide {:?}", hash);
+
         let (sender, receiver) = oneshot::channel();
         self.sender
-            .send(Command::LookupBlob { hash, sender })
+            .send(Command::Provide { hash, sender })
+            .await
+            .expect("Command receiver not to be dropped.");
+        receiver.await.expect("Sender not to be dropped.")
+    }
+
+    pub async fn list_providers(&mut self, hash: String) -> HashSet<PeerId> {
+        let (sender, receiver) = oneshot::channel();
+        self.sender
+            .send(Command::ListProviders { hash, sender })
             .await
             .expect("Command receiver not to be dropped.");
         receiver.await.expect("Sender not to be dropped.")
@@ -130,14 +143,18 @@ impl Client {
 
     pub async fn request_artifact(
         &mut self,
-        peer: PeerId,
+        peer: &PeerId,
         hash: String,
     ) -> Result<Vec<u8>, Box<dyn Error + Send>> {
         debug!("p2p::Client::request_artifact {:?}: {:?}", peer, hash);
 
         let (sender, receiver) = oneshot::channel();
         self.sender
-            .send(Command::RequestArtifact { hash, peer, sender })
+            .send(Command::RequestArtifact {
+                hash,
+                peer: *peer,
+                sender,
+            })
             .await
             .expect("Command receiver not to be dropped.");
         receiver.await.expect("Sender not to be dropped.")
@@ -158,7 +175,8 @@ impl Client {
 }
 
 type PendingDialMap = HashMap<PeerId, oneshot::Sender<Result<(), Box<dyn Error + Send>>>>;
-type PendingListPeersMap = HashMap<QueryId, oneshot::Sender<Vec<PeerId>>>;
+type PendingListPeersMap = HashMap<QueryId, oneshot::Sender<HashSet<PeerId>>>;
+type PendingStartProvidingMap = HashMap<QueryId, oneshot::Sender<()>>;
 type PendingRequestArtifactMap =
     HashMap<RequestId, oneshot::Sender<Result<Vec<u8>, Box<dyn Error + Send>>>>;
 
@@ -168,6 +186,8 @@ pub struct EventLoop {
     event_sender: mpsc::Sender<Event>,
     pending_dial: PendingDialMap,
     pending_list_peers: PendingListPeersMap,
+    pending_start_providing: PendingStartProvidingMap,
+    pending_list_providers: PendingListPeersMap,
     pending_request_artifact: PendingRequestArtifactMap,
 }
 
@@ -183,6 +203,8 @@ impl EventLoop {
             event_sender,
             pending_dial: Default::default(),
             pending_list_peers: Default::default(),
+            pending_start_providing: Default::default(),
+            pending_list_providers: Default::default(),
             pending_request_artifact: Default::default(),
         }
     }
@@ -224,7 +246,38 @@ impl EventLoop {
                     .pending_list_peers
                     .remove(&id)
                     .expect("Completed query to be previously pending.")
-                    .send(peers);
+                    .send(HashSet::from_iter(peers));
+            }
+            SwarmEvent::Behaviour(ComposedEvent::Kademlia(
+                KademliaEvent::OutboundQueryCompleted {
+                    id,
+                    result: QueryResult::StartProviding(_),
+                    ..
+                },
+            )) => {
+                let sender: oneshot::Sender<()> = self
+                    .pending_start_providing
+                    .remove(&id)
+                    .expect("Completed query to be previously pending.");
+                let _ = sender.send(());
+            }
+            SwarmEvent::Behaviour(ComposedEvent::Kademlia(
+                KademliaEvent::OutboundQueryCompleted {
+                    id,
+                    result:
+                        QueryResult::GetProviders(Ok(GetProvidersOk {
+                            key: _key,
+                            providers,
+                            ..
+                        })),
+                    ..
+                },
+            )) => {
+                let _ = self
+                    .pending_list_providers
+                    .remove(&id)
+                    .expect("Completed query to be previously pending.")
+                    .send(providers);
             }
             SwarmEvent::Behaviour(ComposedEvent::Kademlia(_)) => {}
             SwarmEvent::Behaviour(ComposedEvent::RequestResponse(
@@ -348,13 +401,22 @@ impl EventLoop {
                     .get_closest_peers(peer_id);
                 self.pending_list_peers.insert(query_id, sender);
             }
-            Command::LookupBlob {
-                hash: _hash,
-                sender,
-            } => {
-                sender
-                    .send(Ok(()))
-                    .expect("Connection to peer to still be open.");
+            Command::Provide { hash, sender } => {
+                let query_id = self
+                    .swarm
+                    .behaviour_mut()
+                    .kademlia
+                    .start_providing(hash.into_bytes().into())
+                    .expect("No store error.");
+                self.pending_start_providing.insert(query_id, sender);
+            }
+            Command::ListProviders { hash, sender } => {
+                let query_id = self
+                    .swarm
+                    .behaviour_mut()
+                    .kademlia
+                    .get_providers(hash.into_bytes().into());
+                self.pending_list_providers.insert(query_id, sender);
             }
             Command::RequestArtifact { hash, peer, sender } => {
                 let request_id = self
@@ -413,11 +475,15 @@ enum Command {
     },
     ListPeers {
         peer_id: PeerId,
-        sender: oneshot::Sender<Vec<PeerId>>,
+        sender: oneshot::Sender<HashSet<PeerId>>,
     },
-    LookupBlob {
+    Provide {
         hash: String,
-        sender: oneshot::Sender<Result<(), Box<dyn Error + Send>>>,
+        sender: oneshot::Sender<()>,
+    },
+    ListProviders {
+        hash: String,
+        sender: oneshot::Sender<HashSet<PeerId>>,
     },
     RequestArtifact {
         hash: String,
@@ -436,7 +502,8 @@ impl Display for Command {
             Command::Listen { .. } => "Listen",
             Command::Dial { .. } => "Dial",
             Command::ListPeers { .. } => "ListPeers",
-            Command::LookupBlob { .. } => "LookupBlob",
+            Command::Provide { .. } => "Provide",
+            Command::ListProviders { .. } => "ListProviders",
             Command::RequestArtifact { .. } => "RequestArtifact",
             Command::RespondArtifact { .. } => "RespondArtifact",
         };

--- a/src/network/p2p.rs
+++ b/src/network/p2p.rs
@@ -43,8 +43,7 @@ use std::iter;
 pub async fn new() -> Result<(Client, impl Stream<Item = Event>, EventLoop), Box<dyn Error>> {
     let local_keys = identity::Keypair::generate_ed25519();
 
-    let identify_config =
-        IdentifyConfig::new(String::from("ipfs/1.0.0"), local_keys.public().clone());
+    let identify_config = IdentifyConfig::new(String::from("ipfs/1.0.0"), local_keys.public());
     let local_peer_id = local_keys.public().to_peer_id();
 
     let swarm = SwarmBuilder::new(
@@ -231,8 +230,8 @@ impl EventLoop {
                 info,
             })) => {
                 println!("Identify::Received: {}; {:?}", peer_id, info);
-                if let Some(addr) = info.listen_addrs.iter().next() {
-                    if let Some(sender) = self.pending_dial.remove(&addr) {
+                if let Some(addr) = info.listen_addrs.get(0) {
+                    if let Some(sender) = self.pending_dial.remove(addr) {
                         let _ = sender.send(Ok(()));
                     }
 

--- a/src/node_api/handlers/swarm.rs
+++ b/src/node_api/handlers/swarm.rs
@@ -54,6 +54,7 @@ pub async fn handle_get_status(mut p2p_client: p2p::Client) -> Result<impl Reply
     let status = Status {
         artifact_count: art_count_result.unwrap(),
         peers_count: peers.len(),
+        peer_id: p2p_client.local_peer_id.to_string(),
         disk_allocated: String::from(ALLOCATED_SPACE_FOR_ARTIFACTS),
         disk_usage: format!("{:.4}", disk_space_result.unwrap()),
     };

--- a/src/node_manager/model/cli.rs
+++ b/src/node_manager/model/cli.rs
@@ -20,6 +20,7 @@ use serde::{Deserialize, Serialize};
 
 pub struct Status {
     pub peers_count: usize,
+    pub peer_id: String,
     pub artifact_count: usize,
     pub disk_allocated: String,
     pub disk_usage: String,


### PR DESCRIPTION
## PR Checklist

<!--

Locally run the build process

-->
- [x] I've built the code `cargo build`. For major changes, `cargo build --workspace --release` is recommended.
- [x] I've run the automated unit tests `cargo test`. This executes our automated unit tests.
- [x] I've not broken any existing tests or functionality. In addition to `cargo test`, I've run `cargo clippy`
- [x] I've not introduced any new known security vulnerabilities. I've run `cargo audit`

<!--

Make certain your Pull Request has the following.

-->
- [x] I've included a brief description and a good title of the proposed changes and how to test them.
- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've associated an [issue](https://github.com/pyrsia/pyrsia/issues) with this Pull Request. 
- [x] I've checked that the code is up-to-date with the `pyrsia/main` branch.
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/good_pr.md)
- [x] I've assigned this Pull Request to "pyrsia/collaborators"

## Description

Fixes pyrsia/pyrsia#444

This PR introduces the following changes:

1. A node can provide an artifact via its hash into the p2p network.
2. When a node needs an artifact that does not yet exist locally, it retrieves a list of providers in the p2p network and requests it from the first provider peer found. If no providers exist, it falls back to fetching the artifact from docker.io.
3. Providing the boot node with `--peer` no longer requires the PeerId of that node. One can simple pass the IP and port, i.e.: `--peer /ip4/127.0.0.1/tcp/41105`
4. Added the local PeerId in the status command:
    ```
    $ curl http://127.0.0.1:7888/status
    {
      "peers_count": 0,
      "peer_id": "12D3KooWRGFnz3uYujWgD3jTMey2cazzfMYYfSdUhf1MNJKgsgcu",
      "artifact_count": 0,
      "disk_allocated": "10.84 GB",
      "disk_usage": "0.0000"
    }
    ```
