### PR TITLE
Provide local artifacts when starting a pyrsia node

### DIFF
--- a/pyrsia_node/src/main.rs
+++ b/pyrsia_node/src/main.rs
@@ -16,15 +16,16 @@
 
 pub mod args;
 
+use args::parser::PyrsiaNodeArgs;
 use pyrsia::docker::error_util::*;
 use pyrsia::docker::v2::routes::make_docker_routes;
 use pyrsia::logging::*;
-use pyrsia::network::handlers::{dial_other_peer, handle_request_artifact};
-use pyrsia::network::p2p::{self};
+use pyrsia::network::handlers::{dial_other_peer, handle_request_artifact, provide_artifacts};
+use pyrsia::network::p2p::{self, Client, Event};
 use pyrsia::node_api::routes::make_node_routes;
 
 use clap::Parser;
-use futures::StreamExt;
+use futures::{Stream, StreamExt};
 use log::{debug, info};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use warp::Filter;
@@ -33,21 +34,9 @@ use warp::Filter;
 async fn main() {
     pretty_env_logger::init();
 
-    let args = args::parser::PyrsiaNodeArgs::parse();
+    let args = PyrsiaNodeArgs::parse();
 
-    let (mut p2p_client, mut p2p_events, event_loop) = p2p::new().await.unwrap();
-
-    tokio::spawn(event_loop.run());
-
-    if let Some(to_dial) = args.peer {
-        dial_other_peer(p2p_client.clone(), to_dial).await;
-    }
-
-    // Listen on all interfaces and whatever port the OS assigns
-    p2p_client
-        .listen(args.listen_address)
-        .await
-        .expect("Listening should not fail");
+    let (p2p_client, mut p2p_events) = setup_p2p(&args).await;
 
     // Get host and port from the settings. Defaults to DEFAULT_HOST and DEFAULT_PORT
     let host = args.host;
@@ -92,4 +81,23 @@ async fn main() {
             }
         }
     }
+}
+
+async fn setup_p2p(args: &PyrsiaNodeArgs) -> (Client, impl Stream<Item = Event>) {
+    let (mut p2p_client, p2p_events, event_loop) = p2p::new().await.unwrap();
+
+    tokio::spawn(event_loop.run());
+
+    p2p_client
+        .listen(&args.listen_address)
+        .await
+        .expect("Listening should not fail");
+
+    if let Some(to_dial) = &args.peer {
+        dial_other_peer(p2p_client.clone(), to_dial).await;
+    }
+
+    provide_artifacts(p2p_client.clone()).await;
+
+    (p2p_client, p2p_events)
 }

--- a/src/artifacts_repository/artifact_manager.rs
+++ b/src/artifacts_repository/artifact_manager.rs
@@ -186,12 +186,31 @@ impl ArtifactManager {
         }
         Ok(total_files)
     }
+
+    /// List all artifacts that are known locally.
+    pub fn list_artifacts(&self) -> Result<Vec<PathBuf>, Error> {
+        let mut artifacts = Vec::new();
+
+        for entry in WalkDir::new(self.repository_path.clone())
+            .into_iter()
+            .filter_entry(is_directory_or_artifact_file)
+            .filter_map(|file| file.ok())
+        {
+            if let Ok(metadata) = entry.metadata() {
+                if metadata.is_file() {
+                    artifacts.push(entry.into_path());
+                }
+            }
+        }
+
+        Ok(artifacts)
+    }
+
     /// Calculate the repository size by recursively adding size of each directory inside it.
-    /// Parameters are:
-    /// * path — directory path of which size need to be calculated.
     /// Returns the size
-    pub fn space_used(&self, repository_path: &str) -> Result<u64, Error> {
-        get_size(repository_path).context("Error while calculating the size of artifact manager")
+    pub fn space_used(&self) -> Result<u64, Error> {
+        get_size(self.repository_path.as_os_str())
+            .context("Error while calculating the size of artifact manager")
     }
 
     /// Push an artifact to this node's local repository.
@@ -539,7 +558,7 @@ mod tests {
 
         // Check the space before pushing artifact
         let space_before = am
-            .space_used(dir_name.as_str())
+            .space_used()
             .context("Error getting space used by ArtifactManager")?;
         assert_eq!(0, space_before);
 
@@ -553,7 +572,7 @@ mod tests {
             fs_extra::dir::get_size(&*am.repository_path.to_string_lossy())?;
         // Check the space used after pushing artifact
         let space_after = am
-            .space_used(dir_name.as_str())
+            .space_used()
             .context("Error getting space used by ArtifactManager")?;
         assert_eq!(
             size_of_files_in_directory_tree, space_after,
@@ -565,8 +584,27 @@ mod tests {
         assert_eq!(
             1,
             am.artifacts_count()?,
-            "artifact manager should have a 1 artifact"
+            "artifact manager should have 1 artifact"
         );
+
+        let artifacts = am.list_artifacts()?;
+        assert_eq!(
+            1,
+            artifacts.len(),
+            "artifact manager should list 1 artifact"
+        );
+        let file_name = format!(
+            "{}/{}.file",
+            dir_name.as_str(),
+            &hash.to_string().replace(":", "/")
+        );
+        assert!(artifacts
+            .get(0)
+            .unwrap()
+            .as_os_str()
+            .to_str()
+            .unwrap()
+            .ends_with(&file_name));
 
         remove_dir_all(&dir_name);
         Ok(())

--- a/src/docker/v2/handlers/blobs.rs
+++ b/src/docker/v2/handlers/blobs.rs
@@ -69,7 +69,7 @@ pub async fn handle_get_blobs(
         }
     }
 
-    p2p_client.provide(String::from(&hash)).await;
+    p2p_client.provide(&hash).await;
 
     debug!("Final Step: {:?} successfully retrieved!", hash);
     Ok(warp::http::response::Builder::new()
@@ -194,7 +194,7 @@ fn store_blob_in_filesystem(
     let append = append_to_blob(&blob_upload_dest_data, bytes)?;
 
     // check if there is enough local allocated disk space
-    let available_space = get_space_available(ARTIFACTS_DIR.as_str());
+    let available_space = get_space_available();
     if available_space.is_err() {
         return Err(available_space.err().unwrap().to_string().into());
     }
@@ -222,12 +222,28 @@ async fn get_blob_from_network(
     hash: &str,
 ) -> Result<bool, Rejection> {
     let providers = p2p_client.list_providers(String::from(hash)).await;
+    debug!(
+        "Step 2: Does {:?} exist in the Pyrsia network? Providers: {:?}",
+        hash, providers
+    );
     Ok(match providers.iter().next() {
-        Some(peer) => match get_blob_from_other_peer(p2p_client.clone(), peer, name, hash).await {
-            true => true,
-            false => get_blob_from_docker_hub(name, hash).await?,
-        },
-        None => get_blob_from_docker_hub(name, hash).await?,
+        Some(peer) => {
+            debug!(
+                "Step 2: YES, {:?} exists in the Pyrsia network, fetching from peer {}.",
+                hash, peer
+            );
+            match get_blob_from_other_peer(p2p_client.clone(), peer, name, hash).await {
+                true => true,
+                false => get_blob_from_docker_hub(name, hash).await?,
+            }
+        }
+        None => {
+            debug!(
+                "Step 2: No, {:?} does not exist in the Pyrsia network, fetching from docker.io.",
+                hash
+            );
+            get_blob_from_docker_hub(name, hash).await?
+        }
     })
 }
 
@@ -243,14 +259,12 @@ async fn get_blob_from_other_peer(
         peer_id,
         hash.get(7..).unwrap()
     );
-    debug!("Step 2: Does {:?} exist in the Pyrsia network?", hash);
     match p2p_client
         .request_artifact(peer_id, String::from(hash))
         .await
     {
         Ok(artifact) => {
             let id = Uuid::new_v4();
-            debug!("Step 2: YES, {:?} exists in the Pyrsia network.", hash);
             match store_blob_in_filesystem(
                 name,
                 &id.to_string(),
@@ -272,12 +286,8 @@ async fn get_blob_from_other_peer(
         }
         Err(error) => {
             debug!(
-                "Step 2: NO, {:?} does not exist in the Pyrsia network.",
-                hash
-            );
-            debug!(
-                "Error while fetching artifact from Pyrsia Node, so fetching from dockerhub: {}",
-                error
+                "Step 2: Error while retrieving {:?} from the Pyrsia network from peer {}: {}",
+                hash, peer_id, error
             );
             false
         }

--- a/src/network/handlers.rs
+++ b/src/network/handlers.rs
@@ -16,18 +16,25 @@
 
 use crate::artifacts_repository::hash_util::HashAlgorithm;
 use crate::network::p2p;
-use crate::node_manager::handlers::get_artifact;
+use crate::node_manager::handlers::{get_artifact, get_artifact_hashes};
 use libp2p::request_response::ResponseChannel;
 use libp2p::Multiaddr;
-use log::info;
+use log::{debug, info};
 
 /// Reach out to another node with the specified address
-pub async fn dial_other_peer(mut p2p_client: p2p::Client, to_dial: Multiaddr) {
-    p2p_client
-        .dial(to_dial.clone())
-        .await
-        .expect("Dial to succeed.");
+pub async fn dial_other_peer(mut p2p_client: p2p::Client, to_dial: &Multiaddr) {
+    p2p_client.dial(to_dial).await.expect("Dial to succeed.");
     info!("Dialed {:?}", to_dial);
+}
+
+/// Provide all known artifacts on the p2p network
+pub async fn provide_artifacts(mut p2p_client: p2p::Client) {
+    if let Ok(artifact_hashes) = get_artifact_hashes() {
+        debug!("Start providing {} artifacts", artifact_hashes.len());
+        for artifact_hash in artifact_hashes.iter() {
+            p2p_client.provide(artifact_hash).await;
+        }
+    }
 }
 
 /// Respond to a RequestArtifact event by getting the artifact from

--- a/src/network/p2p.rs
+++ b/src/network/p2p.rs
@@ -81,23 +81,29 @@ pub struct Client {
 }
 
 impl Client {
-    pub async fn listen(&mut self, addr: Multiaddr) -> Result<(), Box<dyn Error + Send>> {
+    pub async fn listen(&mut self, addr: &Multiaddr) -> Result<(), Box<dyn Error + Send>> {
         debug!("p2p::Client::listen {:?}", addr);
 
         let (sender, receiver) = oneshot::channel();
         self.sender
-            .send(Command::Listen { addr, sender })
+            .send(Command::Listen {
+                addr: addr.clone(),
+                sender,
+            })
             .await
             .expect("Command receiver not to be dropped.");
         receiver.await.expect("Sender not to be dropped.")
     }
 
-    pub async fn dial(&mut self, peer_addr: Multiaddr) -> Result<(), Box<dyn Error + Send>> {
+    pub async fn dial(&mut self, peer_addr: &Multiaddr) -> Result<(), Box<dyn Error + Send>> {
         debug!("p2p::Client::dial {:?}", peer_addr);
 
         let (sender, receiver) = oneshot::channel();
         self.sender
-            .send(Command::Dial { peer_addr, sender })
+            .send(Command::Dial {
+                peer_addr: peer_addr.clone(),
+                sender,
+            })
             .await
             .expect("Command receiver not to be dropped.");
         receiver.await.expect("Sender not to be dropped.")
@@ -115,12 +121,15 @@ impl Client {
         receiver.await.expect("Sender not to be dropped.")
     }
 
-    pub async fn provide(&mut self, hash: String) {
+    pub async fn provide(&mut self, hash: &str) {
         debug!("p2p::Client::provide {:?}", hash);
 
         let (sender, receiver) = oneshot::channel();
         self.sender
-            .send(Command::Provide { hash, sender })
+            .send(Command::Provide {
+                hash: String::from(hash),
+                sender,
+            })
             .await
             .expect("Command receiver not to be dropped.");
         receiver.await.expect("Sender not to be dropped.")

--- a/src/node_api/handlers/swarm.rs
+++ b/src/node_api/handlers/swarm.rs
@@ -44,7 +44,7 @@ pub async fn handle_get_status(mut p2p_client: p2p::Client) -> Result<impl Reply
         }));
     }
 
-    let disk_space_result = disk_usage(ARTIFACTS_DIR.as_str());
+    let disk_space_result = disk_usage();
     if disk_space_result.is_err() {
         return Err(warp::reject::custom(RegistryError {
             code: RegistryErrorCode::Unknown(disk_space_result.err().unwrap().to_string()),

--- a/src/node_manager/handlers.rs
+++ b/src/node_manager/handlers.rs
@@ -94,6 +94,31 @@ pub fn get_artifact(art_hash: &[u8], algorithm: HashAlgorithm) -> Result<Vec<u8>
     Ok(blob_content)
 }
 
+//get_artifact_hashes: retrieve a list of hashes of all artifacts that are stored in
+//                     the artifact_manager
+pub fn get_artifact_hashes() -> Result<Vec<String>, anyhow::Error> {
+    let artifacts = ART_MGR.list_artifacts()?;
+    Ok(artifacts
+        .into_iter()
+        .map(|artifact| {
+            let hash_type = artifact
+                .parent()
+                .unwrap()
+                .file_name()
+                .unwrap()
+                .to_str()
+                .unwrap();
+            let hash_value = artifact.file_name().unwrap().to_str().unwrap();
+            let extension_dot = hash_value.rfind('.').unwrap();
+            format!(
+                "{}:{}",
+                hash_type.to_lowercase(),
+                hash_value.get(0..extension_dot).unwrap()
+            )
+        })
+        .collect())
+}
+
 //put_artifact: given artifact_hash(artifactName) & artifact_path push artifact to artifact_manager
 //              and returns the boolean as true or false if it was able to create or not
 pub fn put_artifact(
@@ -115,8 +140,8 @@ pub fn get_arts_count() -> Result<usize, anyhow::Error> {
         .context("Error while getting artifacts count")
 }
 
-pub fn get_space_available(repository_path: &str) -> Result<u64, anyhow::Error> {
-    let disk_used_bytes = ART_MGR.space_used(repository_path)?;
+pub fn get_space_available() -> Result<u64, anyhow::Error> {
+    let disk_used_bytes = ART_MGR.space_used()?;
 
     let mut available_space: u64 = 0;
     let total_allocated_size: u64 = Byte::from_str(ALLOCATED_SPACE_FOR_ARTIFACTS)
@@ -129,8 +154,8 @@ pub fn get_space_available(repository_path: &str) -> Result<u64, anyhow::Error> 
     Ok(available_space)
 }
 
-pub fn disk_usage(repository_path: &str) -> Result<f64, anyhow::Error> {
-    let disk_used_bytes = ART_MGR.space_used(repository_path)?;
+pub fn disk_usage() -> Result<f64, anyhow::Error> {
+    let disk_used_bytes = ART_MGR.space_used()?;
 
     let total_allocated_size: u64 = Byte::from_str(ALLOCATED_SPACE_FOR_ARTIFACTS)
         .unwrap()
@@ -148,7 +173,6 @@ pub fn disk_usage(repository_path: &str) -> Result<f64, anyhow::Error> {
 #[cfg(test)]
 
 mod tests {
-    use super::ArtifactManager;
     use super::HashAlgorithm;
     use super::*;
     use anyhow::Context;
@@ -157,7 +181,6 @@ mod tests {
     use std::fs::File;
     use std::path::Path;
     use std::path::PathBuf;
-    use tempfile::Builder;
 
     use super::Hash;
 
@@ -182,8 +205,7 @@ mod tests {
         ],
         teardown = tear_down()
         )]
-    fn put_and_get_artifact_test() {
-        debug!("put_and_get_artifact_test started !!");
+    fn test_put_and_get_artifact() {
         //put the artifact
         put_artifact(
             &VALID_ARTIFACT_HASH,
@@ -216,47 +238,58 @@ mod tests {
 
     #[assay(
         env = [
-          ("PYRSIA_ARTIFACT_PATH", "PyrisaTest"),
+          ("PYRSIA_ARTIFACT_PATH", "PyrsiaTest"),
           ("DEV_MODE", "on")
         ]  )]
     fn test_disk_usage() {
-        let tmp_dir = Builder::new().prefix("PyrisaTest").tempdir()?;
-        let tmp_path = tmp_dir.path().to_owned();
-        assert!(tmp_path.exists());
+        let usage_pct_before = disk_usage().context("Error from disk_usage")?;
 
-        let name = tmp_path.to_str().unwrap();
+        create_artifact().context("Error creating artifact")?;
 
-        let am: ArtifactManager = ArtifactManager::new(name)?;
-
-        let usage_pct_before = disk_usage(name).context("Error from disk_usage")?;
-
-        create_artifact(am).context("Error creating artifact")?;
-
-        let usage_pct_after = disk_usage(name).context("Error from disk_usage")?;
+        let usage_pct_after = disk_usage().context("Error from disk_usage")?;
         assert!(usage_pct_before < usage_pct_after);
     }
 
     #[assay(
         env = [
-          ("PYRSIA_ARTIFACT_PATH", "PyrisaTest"),
+          ("PYRSIA_ARTIFACT_PATH", "PyrsiaTest"),
           ("DEV_MODE", "on")
         ]  )]
     fn test_get_space_available() {
-        let tmp_dir = Builder::new().prefix("PyrisaTest").tempdir()?;
-        let tmp_path = tmp_dir.path().to_owned();
-        assert!(tmp_path.exists());
-
-        let name = tmp_path.to_str().unwrap();
-
-        let am: ArtifactManager = ArtifactManager::new(name)?;
         let space_available_before =
-            get_space_available(name).context("Error from get_space_available")?;
+            get_space_available().context("Error from get_space_available")?;
 
-        create_artifact(am).context("Error creating artifact")?;
+        create_artifact().context("Error creating artifact")?;
 
         let space_available_after =
-            get_space_available(name).context("Error from get_space_available")?;
+            get_space_available().context("Error from get_space_available")?;
+        debug!(
+            "Before: {}; After: {}",
+            space_available_before, space_available_after
+        );
         assert!(space_available_after < space_available_before);
+    }
+
+    #[assay(
+        env = [
+          ("PYRSIA_ARTIFACT_PATH", "PyrsiaTest"),
+          ("DEV_MODE", "on")
+        ]  )]
+    fn test_get_artifact_hashes_is_empty() {
+        let artifact_hashes = get_artifact_hashes().context("Error from get_artifact_hashes")?;
+        assert!(artifact_hashes.is_empty());
+    }
+
+    #[assay(
+        env = [
+          ("PYRSIA_ARTIFACT_PATH", "PyrsiaTest"),
+          ("DEV_MODE", "on")
+        ]  )]
+    fn test_get_artifact_hashes() {
+        create_artifact().context("Error creating artifact")?;
+
+        let artifact_hashes = get_artifact_hashes().context("Error from get_artifact_hashes")?;
+        assert!(artifact_hashes.len() == 1);
     }
 
     fn get_file_reader() -> Result<File, anyhow::Error> {
@@ -269,9 +302,9 @@ mod tests {
         Ok(reader)
     }
 
-    fn create_artifact(am: ArtifactManager) -> Result<(), anyhow::Error> {
+    fn create_artifact() -> Result<(), anyhow::Error> {
         let hash = Hash::new(HashAlgorithm::SHA256, &VALID_ARTIFACT_HASH)?;
-        let push_result = am
+        let push_result = ART_MGR
             .push_artifact(&mut get_file_reader()?, &hash)
             .context("Error while pushing artifact")?;
 


### PR DESCRIPTION
## PR Checklist

<!--

Locally run the build process

-->
- [x] I've built the code `cargo build`. For major changes, `cargo build --workspace --release` is recommended.
- [x] I've run the automated unit tests `cargo test`. This executes our automated unit tests.
- [x] I've not broken any existing tests or functionality. In addition to `cargo test`, I've run `cargo clippy`
- [x] I've not introduced any new known security vulnerabilities. I've run `cargo audit`

<!--

Make certain your Pull Request has the following.

-->
- [x] I've included a brief description and a good title of the proposed changes and how to test them.
- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've associated an [issue](https://github.com/pyrsia/pyrsia/issues) with this Pull Request. 
- [x] I've checked that the code is up-to-date with the `pyrsia/main` branch.
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/good_pr.md)
- [x] I've assigned this Pull Request to "pyrsia/collaborators"

## Description

Fixes pyrsia/pyrsia#468

When starting a Pyrsia node, it will add itself as a provider on the kademlia p2p network for all artifacts that are available locally from the artifact manager.
