### PR TITLE
Improve boot component order

### DIFF
--- a/pyrsia_node/src/main.rs
+++ b/pyrsia_node/src/main.rs
@@ -76,7 +76,7 @@ fn setup_http(args: &PyrsiaNodeArgs, p2p_client: p2p::Client) {
 
     debug!("Setup HTTP routing");
     let docker_routes = make_docker_routes(p2p_client.clone());
-    let node_api_routes = make_node_routes(p2p_client.clone());
+    let node_api_routes = make_node_routes(p2p_client);
     let all_routes = docker_routes.or(node_api_routes);
 
     debug!("Setup HTTP server");

--- a/pyrsia_node/src/main.rs
+++ b/pyrsia_node/src/main.rs
@@ -21,11 +21,11 @@ use pyrsia::docker::error_util::*;
 use pyrsia::docker::v2::routes::make_docker_routes;
 use pyrsia::logging::*;
 use pyrsia::network::handlers::{dial_other_peer, handle_request_artifact, provide_artifacts};
-use pyrsia::network::p2p::{self, Client, Event};
+use pyrsia::network::p2p;
 use pyrsia::node_api::routes::make_node_routes;
 
 use clap::Parser;
-use futures::{Stream, StreamExt};
+use futures::StreamExt;
 use log::{debug, info};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use warp::Filter;
@@ -34,43 +34,22 @@ use warp::Filter;
 async fn main() {
     pretty_env_logger::init();
 
+    debug!("Parse CLI arguments");
     let args = PyrsiaNodeArgs::parse();
 
-    let (p2p_client, mut p2p_events) = setup_p2p(&args).await;
+    debug!("Create p2p components");
+    let (p2p_client, mut p2p_events, event_loop) = p2p::create_components().await.unwrap();
 
-    // Get host and port from the settings. Defaults to DEFAULT_HOST and DEFAULT_PORT
-    let host = args.host;
-    let port = args.port;
-    debug!(
-        "Pyrsia Docker Node will bind to host = {}, port = {}",
-        host, port
-    );
+    debug!("Start p2p event loop");
+    tokio::spawn(event_loop.run());
 
-    let address = SocketAddr::new(
-        IpAddr::V4(host.parse::<Ipv4Addr>().unwrap()),
-        port.parse::<u16>().unwrap(),
-    );
+    debug!("Setup HTTP server");
+    setup_http(&args, p2p_client.clone());
 
-    let docker_routes = make_docker_routes(p2p_client.clone());
-    let node_api_routes = make_node_routes(p2p_client.clone());
-    let all_routes = docker_routes.or(node_api_routes);
+    debug!("Start p2p components");
+    setup_p2p(p2p_client.clone(), args).await;
 
-    let (addr, server) = warp::serve(
-        all_routes
-            .and(http::log_headers())
-            .recover(custom_recover)
-            .with(warp::log("pyrsia_registry")),
-    )
-    .bind_ephemeral(address);
-
-    info!(
-        "Pyrsia Docker Node is now running on port {}:{}!",
-        addr.ip(),
-        addr.port()
-    );
-
-    tokio::spawn(server);
-
+    debug!("Listen for p2p events");
     loop {
         if let Some(event) = p2p_events.next().await {
             match event {
@@ -83,21 +62,51 @@ async fn main() {
     }
 }
 
-async fn setup_p2p(args: &PyrsiaNodeArgs) -> (Client, impl Stream<Item = Event>) {
-    let (mut p2p_client, p2p_events, event_loop) = p2p::new().await.unwrap();
+fn setup_http(args: &PyrsiaNodeArgs, p2p_client: p2p::Client) {
+    // Get host and port from the settings. Defaults to DEFAULT_HOST and DEFAULT_PORT
+    debug!(
+        "Pyrsia Docker Node will bind to host = {}, port = {}",
+        args.host, args.port
+    );
 
-    tokio::spawn(event_loop.run());
+    let address = SocketAddr::new(
+        IpAddr::V4(args.host.parse::<Ipv4Addr>().unwrap()),
+        args.port.parse::<u16>().unwrap(),
+    );
 
+    debug!("Setup HTTP routing");
+    let docker_routes = make_docker_routes(p2p_client.clone());
+    let node_api_routes = make_node_routes(p2p_client.clone());
+    let all_routes = docker_routes.or(node_api_routes);
+
+    debug!("Setup HTTP server");
+    let (addr, server) = warp::serve(
+        all_routes
+            .and(http::log_headers())
+            .recover(custom_recover)
+            .with(warp::log("pyrsia_registry")),
+    )
+    .bind_ephemeral(address);
+
+    info!(
+        "Pyrsia Docker Node will start running on {}:{}",
+        addr.ip(),
+        addr.port()
+    );
+
+    tokio::spawn(server);
+}
+
+async fn setup_p2p(mut p2p_client: p2p::Client, args: PyrsiaNodeArgs) {
     p2p_client
         .listen(&args.listen_address)
         .await
         .expect("Listening should not fail");
 
-    if let Some(to_dial) = &args.peer {
-        dial_other_peer(p2p_client.clone(), to_dial).await;
+    if let Some(to_dial) = args.peer {
+        dial_other_peer(p2p_client.clone(), &to_dial).await;
     }
 
+    debug!("Provide local artifacts");
     provide_artifacts(p2p_client.clone()).await;
-
-    (p2p_client, p2p_events)
 }

--- a/src/network/p2p.rs
+++ b/src/network/p2p.rs
@@ -41,12 +41,13 @@ use std::io;
 use std::iter;
 
 /// Creates the necessary p2p components.
-/// 
+///
 /// The components are:
 ///  * [`Client`]: can be used to interact with the p2p network
 ///  * EventReceiver: a receiver of a Stream of [events][`Event`]
 ///  * [`EventLoop`]: used to process events received from the p2p [`Swarm`] and commands from the p2p [`Client`]
-pub async fn create_components() -> Result<(Client, impl Stream<Item = Event>, EventLoop), Box<dyn Error>> {
+pub async fn create_components(
+) -> Result<(Client, impl Stream<Item = Event>, EventLoop), Box<dyn Error>> {
     let local_keys = identity::Keypair::generate_ed25519();
 
     let identify_config = IdentifyConfig::new(String::from("ipfs/1.0.0"), local_keys.public());

--- a/src/network/p2p.rs
+++ b/src/network/p2p.rs
@@ -40,7 +40,13 @@ use std::fmt::{Display, Formatter};
 use std::io;
 use std::iter;
 
-pub async fn new() -> Result<(Client, impl Stream<Item = Event>, EventLoop), Box<dyn Error>> {
+/// Creates the necessary p2p components.
+/// 
+/// The components are:
+///  * [`Client`]: can be used to interact with the p2p network
+///  * EventReceiver: a receiver of a Stream of [events][`Event`]
+///  * [`EventLoop`]: used to process events received from the p2p [`Swarm`] and commands from the p2p [`Client`]
+pub async fn create_components() -> Result<(Client, impl Stream<Item = Event>, EventLoop), Box<dyn Error>> {
     let local_keys = identity::Keypair::generate_ed25519();
 
     let identify_config = IdentifyConfig::new(String::from("ipfs/1.0.0"), local_keys.public());
@@ -81,6 +87,7 @@ pub struct Client {
 }
 
 impl Client {
+    /// Instruct the p2p swarm to start listening on the specified address.
     pub async fn listen(&mut self, addr: &Multiaddr) -> Result<(), Box<dyn Error + Send>> {
         debug!("p2p::Client::listen {:?}", addr);
 
@@ -95,6 +102,7 @@ impl Client {
         receiver.await.expect("Sender not to be dropped.")
     }
 
+    /// Dial a peer with the specified address.
     pub async fn dial(&mut self, peer_addr: &Multiaddr) -> Result<(), Box<dyn Error + Send>> {
         debug!("p2p::Client::dial {:?}", peer_addr);
 
@@ -109,6 +117,7 @@ impl Client {
         receiver.await.expect("Sender not to be dropped.")
     }
 
+    /// List the peers that this node is connected to.
     pub async fn list_peers(&mut self) -> HashSet<PeerId> {
         let (sender, receiver) = oneshot::channel();
         self.sender
@@ -121,6 +130,8 @@ impl Client {
         receiver.await.expect("Sender not to be dropped.")
     }
 
+    /// Inform the p2p network that this node is currently a
+    /// provider of the artifact with the specified `hash`.
     pub async fn provide(&mut self, hash: &str) {
         debug!("p2p::Client::provide {:?}", hash);
 
@@ -135,6 +146,8 @@ impl Client {
         receiver.await.expect("Sender not to be dropped.")
     }
 
+    /// List all peers in the p2p network that are providing
+    /// the artifact with the specified `hash`.
     pub async fn list_providers(&mut self, hash: String) -> HashSet<PeerId> {
         let (sender, receiver) = oneshot::channel();
         self.sender
@@ -144,6 +157,8 @@ impl Client {
         receiver.await.expect("Sender not to be dropped.")
     }
 
+    /// Request an artifact with the specified `hash` from the
+    /// p2p network.
     pub async fn request_artifact(
         &mut self,
         peer: &PeerId,
@@ -163,6 +178,7 @@ impl Client {
         receiver.await.expect("Sender not to be dropped.")
     }
 
+    /// Put the artifact as a response to an incoming request.
     pub async fn respond_artifact(
         &mut self,
         artifact: Vec<u8>,


### PR DESCRIPTION
## Description

Fixes pyrsia/pyrsia#489

This changes the boot order of the components of pyrsia node. Specifically, it makes sure that the HTTP server (that is used for the pyrsia status and docker registry endpoints) is booted first, before the p2p network is initialized.

I've also started adding basic documentation on the p2p component.

## PR Checklist

<!--

Make certain your Pull Request has the following.

-->
- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/good_pr.md)
- [x] I've included a good title and brief description along with how to review them.
- [x] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).
- [x] I've requested a review  from "pyrsia/collaborators"

<!--

Locally run the build process (required for code changes, or you can remove this section).
For a complete list of steps, check out the [developer workflow](https://github.com/pyrsia/pyrsia/blob/main/docs/dev_workflow.md)!

-->
### Code Contributions

- [x] I've built the code `cargo build --workspace`.
- [x] I've run the unit tests `cargo test --workspace`.
