### PR TITLE
Avoid running lint jobs if `rs` files weren't changed

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,8 @@ jobs:
         with:
           files: |
             **/*.rs
+            Cargo.toml
+            Cargo.lock
 
   security-audit:
     needs: rust-files

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,40 +1,32 @@
 name: Linting
 on:
-# TODO: return after review
-  push:
+  pull_request:
 
 permissions:
   checks: write
   pull-requests: write
 
 jobs:
-  check:
-    name: Check rust files were changed
-    outputs:
-      run_job: ${{ steps.check_files.outputs.run_job }}
-    runs-on: ubuntu-latest
-    steps:
+
+  rust-files:
+      runs-on: ubuntu-latest
+      outputs:
+        any_changed: ${{ steps.changed-rust-files.outputs.any_changed }}
+      steps:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-
-      - name: check modified files
-        id: check_files
-        run: |
-            echo "Next files were changed"
-            git diff --name-only origin/main
-            RUST_FILES="$(git diff --name-only origin/main | grep ".rs$")" || true
-            if [[ -z "$RUST_FILES" ]]; then
-              echo "::set-output name=run_job::false"
-              break
-            else
-              echo "::set-output name=run_job::true"
-            fi
+      - name: Get changed rust files
+        id: changed-rust-files
+        uses: tj-actions/changed-files@v18.6
+        with:
+          files: |
+            **/*.rs
 
   security-audit:
-    needs: check
-    if: needs.check.outputs.run_job == 'true'
+    needs: rust-files
+    if: needs.rust-files.outputs.any_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -45,8 +37,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
   rustfmt:
-    needs: check
-    if: needs.check.outputs.run_job == 'true'
+    needs: rust-files
+    if: needs.rust-files.outputs.any_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -56,8 +48,8 @@ jobs:
         run: echo "::error ::You need to run `rustfmt` loaclly, commit the changes, and push"
 
   clippy:
-    needs: check
-    if: needs.check.outputs.run_job == 'true'
+    needs: rust-files
+    if: needs.rust-files.outputs.any_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -68,8 +60,8 @@ jobs:
           args: --all-features -- --deny warnings
 
   license-header:
-    needs: check
-    if: needs.check.outputs.run_job == 'true'
+    needs: rust-files
+    if: needs.rust-files.outputs.any_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -79,8 +71,8 @@ jobs:
           config: .github/license-check/config.json
 
   inclusive-lint:
-    needs: check
-    if: needs.check.outputs.run_job == 'true'
+    needs: rust-files
+    if: needs.rust-files.outputs.any_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,13 +1,40 @@
 name: Linting
 on:
-  pull_request:
+# TODO: return after review
+  push:
 
 permissions:
   checks: write
   pull-requests: write
 
 jobs:
+  check:
+    name: Check rust files were changed
+    outputs:
+      run_job: ${{ steps.check_files.outputs.run_job }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: check modified files
+        id: check_files
+        run: |
+            echo "Next files were changed"
+            git diff --name-only origin/main
+            RUST_FILES="$(git diff --name-only origin/main | grep ".rs$")" || true
+            if [[ -z "$RUST_FILES" ]]; then
+              echo "::set-output name=run_job::false"
+              break
+            else
+              echo "::set-output name=run_job::true"
+            fi
+
   security-audit:
+    needs: check
+    if: needs.check.outputs.run_job == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -18,6 +45,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
   rustfmt:
+    needs: check
+    if: needs.check.outputs.run_job == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -27,6 +56,8 @@ jobs:
         run: echo "::error ::You need to run `rustfmt` loaclly, commit the changes, and push"
 
   clippy:
+    needs: check
+    if: needs.check.outputs.run_job == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -37,6 +68,8 @@ jobs:
           args: --all-features -- --deny warnings
 
   license-header:
+    needs: check
+    if: needs.check.outputs.run_job == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -46,11 +79,13 @@ jobs:
           config: .github/license-check/config.json
 
   inclusive-lint:
+    needs: check
+    if: needs.check.outputs.run_job == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Run Woke for Inclusive Linting
         run: |
             curl -sSfL https://git.io/getwoke | bash -s --
-            bin/woke --exit-1-on-failure 
+            bin/woke --exit-1-on-failure
         shell: bash


### PR DESCRIPTION
ci: avoid runs if rs files weren't changed

We don't need to run linting tasks if rust files are same with HEAD.
GithHub Actions provide ability to skip task by conditions. Was added
check that there are changed rust files. If check returns True we
execute linting and others workflows, otherwise, GitHub Actions
should skip them.

Close: pyrsia/pyrsia#479


## Runs links with example
when we have to skip jobs: [this](https://github.com/VitaliyaIoffe/pyrsia/actions/runs/2098578301)
when job should be triggered: [that](https://github.com/VitaliyaIoffe/pyrsia/actions/runs/2098526448)



## PR Checklist

<!--

Make certain you've done the following.

-->

- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/good_pr.md)
- [x] I've included a good title and brief description along with how to review them.
- [x] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).
- [X] I've requested a review  from `pyrsia/collaborators`.

### Code Contributions

<!--

This section applies to code modifications, you may remove it otherwise.

Make sure your Pull Request will pass the CI/CD pipeline.
For a complete list of steps, check out the [developer workflow](https://github.com/pyrsia/pyrsia/blob/main/docs/dev_workflow.md)!

-->
I don't do next, because it is workflow changes

- [ ] I've built the code `cargo build --all-targets` successfully.
- [ ] I've run the unit tests `cargo test --workspace` and everything passes.


And I need some help to understand with what branches shoud we compare current. Is it good approach for your team?
Any other points?
Are these jobs chosen correctly?
