### PR TITLE
Proposing a fix for issue found with config file losing configured va…

### DIFF
--- a/src/cli_commands/config.rs
+++ b/src/cli_commands/config.rs
@@ -20,7 +20,7 @@ use std::fmt::{Display, Formatter};
 
 const CONF_FILE: &str = "pyrsia-cli";
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CliConfig {
     pub host: String,
     pub port: String,
@@ -94,13 +94,18 @@ mod tests {
     #[assay(teardown = tear_down())]
     fn test_config_file_update() {
         let cfg: CliConfig = get_config().expect("could not get conf file");
-        assert_eq!(cfg.port, "7888".to_string());
-        let cfg = CliConfig {
+        let cfg2: CliConfig = CliConfig {
+            port: "7888".to_string(),
+            ..cfg.clone()
+        };
+        let cfg3: CliConfig = CliConfig {
             port: "7878".to_string(),
-            ..cfg
+            ..cfg.clone()
         };
 
-        add_config(cfg).expect("could not update conf file");
+        add_config(cfg2.clone()).expect("could not update conf file");
+        assert_eq!(cfg2.port, "7888".to_string());
+        add_config(cfg3).expect("could not update conf file");
         let new_cfg: CliConfig = get_config().expect("could not get conf file");
         assert_eq!(new_cfg.port, "7878".to_string());
     }


### PR DESCRIPTION
…lue in test.

<!--

Thank you for participating with our effort to build a more secure software supply chain.
Before submitting your Pull Request, please go over our check list.

-->

## Description

Fixes pyrsia/pyrsia#637

<!--

Try to fill in the following to help the reviewers dive into the pull request.
Explain the context and what changed.

-->

This PR makes sure the default port of `7888` is set before testing that. You can test the changes by running `cargo test` twice. An alternative workaround is to remove `$HOME/Library/Preferences/rs.pyrsia-cli/pyrsia-cli.toml` before running test. **Or** you can set the port to `7888` in that file.

## Screenshots (optional)


## PR Checklist

<!--

Make certain you've done the following.

-->

- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/good_pr.md)
- [x] I've included a good title and brief description along with how to review them.
- [x] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).
- [x] I've requested a review  from `pyrsia/collaborators`.

### Code Contributions

<!--

This section applies to code modifications, you may remove it otherwise.

Make sure your Pull Request will pass the CI/CD pipeline.
For a complete list of steps, check out the [developer workflow](https://github.com/pyrsia/pyrsia/blob/main/docs/dev_workflow.md)!

-->

- [x] I've built the code `cargo build --all-targets` successfully.
- [x] I've run the unit tests `cargo test --workspace` and everything passes.
- [x] I've made sure my rust toolchain is current `rustup update`.
