### PR TITLE
Add workaround for missing status checks in CI

### DIFF
--- a/.github/workflows/rust-lint-skipped.yml
+++ b/.github/workflows/rust-lint-skipped.yml
@@ -1,0 +1,28 @@
+# This implements the workaround described in https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+# The rust linting checks are required but due to path filtering
+# the jobs are not created at all so we need to manually recreate them
+
+name: Rust Linting 
+on:
+  pull_request:
+    path-ignored: # This should match https://github.com/pyrsia/pyrsia/blob/main/.github/workflows/rust-lint.yml#L4
+      - .github/workflows/rust-lint.yml
+      - '**/*.rs'
+      - '**/Cargo.toml'
+      - Cargo.lock
+      
+jobs:
+  security-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No build required"
+
+  rustfmt:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No build required"
+
+  license-header:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No build required"

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -1,7 +1,7 @@
 name: Rust Linting 
 on:
   pull_request:
-    paths:
+    paths: # Make sure to keep sync'd https://github.com/pyrsia/pyrsia/blob/main/.github/workflows/rust-lint-skipped.yml#L8
       - .github/workflows/rust-lint.yml
       - '**/*.rs'
       - '**/Cargo.toml'


### PR DESCRIPTION
<!--

Thank you for participating with our effort to build a more secure software supply chain.
Before submitting your Pull Request, please go over our check list.

-->

## Description



<!--

Try to fill in the following to help the reviewers dive into the pull request.
Explain the context and what changed.

-->

Follow #692 the new `paths` filter on the run lint workflow had some unintended side effects were required jobs were no longer being created. This implements the workaround documented by GitHub.

https://openssf.slack.com/archives/C0302CVKPA5/p1652658860960049

## Screenshots (optional)


## PR Checklist

<!--

Make certain you've done the following.

-->

- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/good_pr.md)
- [x] I've included a good title and brief description along with how to review them.
- [x] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).
- [x] I've requested a review  from `pyrsia/collaborators`.