### PR TITLE
allow larger number of keys to be provided 

### DIFF
--- a/pyrsia_node/src/args/parser.rs
+++ b/pyrsia_node/src/args/parser.rs
@@ -19,6 +19,7 @@ use libp2p::Multiaddr;
 
 const DEFAULT_HOST: &str = "127.0.0.1";
 const DEFAULT_LISTEN_ADDRESS: &str = "/ip4/0.0.0.0/tcp/0";
+const DEFAULT_MAX_PROVIDED_KEYS: &str = "32768";
 const DEFAULT_PORT: &str = "7888";
 
 /// Application to connect to and participate in the Pyrsia network
@@ -37,4 +38,7 @@ pub struct PyrsiaNodeArgs {
     /// An address to connect with another Pyrsia Node (eg /ip4/127.0.0.1/tcp/45153/p2p/12D3KooWKsHbKbcVgyiRRgeXGCK4bp3MngnSU7ioeKTfQzd18B2v)
     #[clap(long, short = 'P')]
     pub peer: Option<Multiaddr>,
+    /// The maximum number of keys that can be provided on the network by this Pyrsia Node.
+    #[clap(long, default_value = DEFAULT_MAX_PROVIDED_KEYS)]
+    pub max_provided_keys: usize,
 }

--- a/pyrsia_node/src/main.rs
+++ b/pyrsia_node/src/main.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let args = PyrsiaNodeArgs::parse();
 
     debug!("Create p2p components");
-    let (p2p_client, mut p2p_events, event_loop) = p2p::setup_libp2p_swarm()?;
+    let (p2p_client, mut p2p_events, event_loop) = p2p::setup_libp2p_swarm(args.max_provided_keys)?;
 
     debug!("Start p2p event loop");
     tokio::spawn(event_loop.run());


### PR DESCRIPTION
## Description

Partial fix for pyrsia/pyrsia#701 (problem 2) 

allow larger number of keys to be provided (was capped at default value of 1024) so the central node can be started with a higher value


- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/good_pr.md)
- [x] I've included a good title and brief description along with how to review them.
- [x] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).
- [x] I've requested a review  from `pyrsia/collaborators`.

### Code Contributions

- [x] I've built the code `cargo build --all-targets` successfully.
- [x] I've run the unit tests `cargo test --workspace` and everything passes.
- [x] I've made sure my rust toolchain is current `rustup update`.
