### PR TITLE
Attempt to fix auto assignment of collaborators

### DIFF
--- a/.github/workflows/board-automation.yml
+++ b/.github/workflows/board-automation.yml
@@ -45,7 +45,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.payload.number,
-              team_reviewers: ["pyrsia/collaborators"],
+              team_reviewers: ["collaborators"],
             });
     
   drafting-pr:


### PR DESCRIPTION
<!--

Thank you for participating with our effort to build a more secure software supply chain.
Before submitting your Pull Request, please go over our check list.

-->

## Description

Thus far we have been manually adding the `collaborators` review to the dependabot PRs, which should also get it once it's opened...

We had previously tried to automate this but it never worked.

https://github.com/pyrsia/pyrsia/blob/e411d07a33d39cba1c1a245b7ea4437edff2d891/.github/workflows/board-automation.yml#L27

Since there was a recent PR update to the tool, I wanted to check again and it did "successfully" run https://github.com/pyrsia/pyrsia/runs/6515517527?check_suite_focus=true

But no assignment was made...

GitHub has updated the docs https://docs.github.com/en/rest/pulls/review-requests#request-reviewers-for-a-pull-request

![image](https://user-images.githubusercontent.com/16867443/169577811-0368980f-549f-4deb-ab8f-0f2174341751.png)

Following https://fabian-kostadinov.github.io/2015/01/16/how-to-find-a-github-team-id/

Our `slug` is 

![image](https://user-images.githubusercontent.com/16867443/169577936-453f8d32-de26-4a66-bbc4-5d2ba2f41a28.png)


## PR Checklist

<!--

Make certain you've done the following.

-->

- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/good_pr.md)
- [x] I've included a good title and brief description along with how to review them.
- [x] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).
- [x] I've requested a review  from `pyrsia/collaborators`.