### PR TITLE
Avoid running cov jobs if `rs` files weren't changed

### DIFF
--- a/.github/workflows/rust-skipped.yml
+++ b/.github/workflows/rust-skipped.yml
@@ -12,7 +12,6 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  # OS/X  Build Job 
   build-osx:
     runs-on: macos-latest
     steps:
@@ -23,7 +22,6 @@ jobs:
     steps:
       - run: echo "No build required"
 
-  # Coverage wipes the cache in order to instrument the code.  No need to wait for other jobs to run it.
   coverage:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rust-skipped.yml
+++ b/.github/workflows/rust-skipped.yml
@@ -1,0 +1,51 @@
+name: Rust
+
+on:
+  push:
+    branches: [ main ]
+    path-ignored: # Make sure to keep sync'd https://github.com/pyrsia/pyrsia/blob/main/.github/workflows/rust-lint-skipped.yml#L8
+      - .github/workflows/rust.yml
+      - '**/*.rs'
+      - '**/Cargo.toml'
+      - Cargo.lock
+  pull_request:
+    path-ignored: # Make sure to keep sync'd https://github.com/pyrsia/pyrsia/blob/main/.github/workflows/rust-lint-skipped.yml#L8
+      - .github/workflows/rust.yml
+      - '**/*.rs'
+      - '**/Cargo.toml'
+      - Cargo.lock
+  release: 
+    path-ignored: # Make sure to keep sync'd https://github.com/pyrsia/pyrsia/blob/main/.github/workflows/rust-lint-skipped.yml#L8
+      - .github/workflows/rust.yml
+      - '**/*.rs'
+      - '**/Cargo.toml'
+      - Cargo.lock
+    types: [published]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # OS/X  Build Job 
+  build-osx:
+    runs-on: macos-latest
+    steps:
+      - run: echo "No build required"
+
+  build-push-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No build required"
+
+  # Coverage wipes the cache in order to instrument the code.  No need to wait for other jobs to run it.
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No build required"
+  
+  # Docker build that uses the published .deb file from the Linux build
+  docker:
+    runs-on: ubuntu-latest
+    needs: [build-push-linux]
+    steps:
+      - run: echo "No build required"

--- a/.github/workflows/rust-skipped.yml
+++ b/.github/workflows/rust-skipped.yml
@@ -2,7 +2,7 @@ name: Rust
 
 on:
   pull_request:
-    path-ignored: # Make sure to keep sync'd https://github.com/pyrsia/pyrsia/blob/main/.github/workflows/rust-lint-skipped.yml#L8
+    path-ignored: # Make sure to keep sync'd https://github.com/pyrsia/pyrsia/blob/main/.github/workflows/rust.yml#L8
       - .github/workflows/rust.yml
       - '**/*.rs'
       - '**/Cargo.toml'

--- a/.github/workflows/rust-skipped.yml
+++ b/.github/workflows/rust-skipped.yml
@@ -1,26 +1,12 @@
 name: Rust
 
 on:
-  push:
-    branches: [ main ]
-    path-ignored: # Make sure to keep sync'd https://github.com/pyrsia/pyrsia/blob/main/.github/workflows/rust-lint-skipped.yml#L8
-      - .github/workflows/rust.yml
-      - '**/*.rs'
-      - '**/Cargo.toml'
-      - Cargo.lock
   pull_request:
     path-ignored: # Make sure to keep sync'd https://github.com/pyrsia/pyrsia/blob/main/.github/workflows/rust-lint-skipped.yml#L8
       - .github/workflows/rust.yml
       - '**/*.rs'
       - '**/Cargo.toml'
       - Cargo.lock
-  release: 
-    path-ignored: # Make sure to keep sync'd https://github.com/pyrsia/pyrsia/blob/main/.github/workflows/rust-lint-skipped.yml#L8
-      - .github/workflows/rust.yml
-      - '**/*.rs'
-      - '**/Cargo.toml'
-      - Cargo.lock
-    types: [published]
 
 env:
   CARGO_TERM_COLOR: always
@@ -40,12 +26,5 @@ jobs:
   # Coverage wipes the cache in order to instrument the code.  No need to wait for other jobs to run it.
   coverage:
     runs-on: ubuntu-latest
-    steps:
-      - run: echo "No build required"
-  
-  # Docker build that uses the published .deb file from the Linux build
-  docker:
-    runs-on: ubuntu-latest
-    needs: [build-push-linux]
     steps:
       - run: echo "No build required"

--- a/.github/workflows/rust-skipped.yml
+++ b/.github/workflows/rust-skipped.yml
@@ -2,7 +2,7 @@ name: Rust
 
 on:
   pull_request:
-    path-ignored: # Make sure to keep sync'd https://github.com/pyrsia/pyrsia/blob/main/.github/workflows/rust.yml#L8
+    paths-ignore: # Make sure to keep sync'd https://github.com/pyrsia/pyrsia/blob/main/.github/workflows/rust.yml#L8
       - .github/workflows/rust.yml
       - '**/*.rs'
       - '**/Cargo.toml'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,11 +3,6 @@ name: Rust
 on:
   push:
     branches: [ main ]
-    paths: # Make sure to keep sync'd https://github.com/pyrsia/pyrsia/blob/main/.github/workflows/rust-lint-skipped.yml#L8
-      - .github/workflows/rust.yml
-      - '**/*.rs'
-      - '**/Cargo.toml'
-      - Cargo.lock
   pull_request:
     paths: # Make sure to keep sync'd https://github.com/pyrsia/pyrsia/blob/main/.github/workflows/rust-lint-skipped.yml#L8
       - .github/workflows/rust.yml

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,8 +3,23 @@ name: Rust
 on:
   push:
     branches: [ main ]
+    paths: # Make sure to keep sync'd https://github.com/pyrsia/pyrsia/blob/main/.github/workflows/rust-lint-skipped.yml#L8
+      - .github/workflows/rust.yml
+      - '**/*.rs'
+      - '**/Cargo.toml'
+      - Cargo.lock
   pull_request:
+    paths: # Make sure to keep sync'd https://github.com/pyrsia/pyrsia/blob/main/.github/workflows/rust-lint-skipped.yml#L8
+      - .github/workflows/rust.yml
+      - '**/*.rs'
+      - '**/Cargo.toml'
+      - Cargo.lock
   release: 
+    paths: # Make sure to keep sync'd https://github.com/pyrsia/pyrsia/blob/main/.github/workflows/rust-lint-skipped.yml#L8
+      - .github/workflows/rust.yml
+      - '**/*.rs'
+      - '**/Cargo.toml'
+      - Cargo.lock
     types: [published]
 
 env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,11 +15,6 @@ on:
       - '**/Cargo.toml'
       - Cargo.lock
   release: 
-    paths: # Make sure to keep sync'd https://github.com/pyrsia/pyrsia/blob/main/.github/workflows/rust-lint-skipped.yml#L8
-      - .github/workflows/rust.yml
-      - '**/*.rs'
-      - '**/Cargo.toml'
-      - Cargo.lock
     types: [published]
 
 env:


### PR DESCRIPTION
Close: pyrsia/pyrsia#577

<!--

Thank you for participating with our effort to build a more secure software supply chain.
Before submitting your Pull Request, please go over our check list.

-->

## Description

Runs code coverage only when .rs, Cargo.toml, and Cargo.lock  have changed.
Uses same implementation as #700.


<!--

Try to fill in the following to help the reviewers dive into the pull request.
Explain the context and what changed.

-->


## Screenshots (optional)


## PR Checklist

<!--

Make certain you've done the following.

-->

- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/good_pr.md)
- [x] I've included a good title and brief description along with how to review them.
- [x] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).

### Code Contributions

<!--

This section applies to code modifications, you may remove it otherwise.

Make sure your Pull Request will pass the CI/CD pipeline.
For a complete list of steps, check out the [developer workflow](https://github.com/pyrsia/pyrsia/blob/main/docs/dev_workflow.md)!

-->

- [x] I've built the code `cargo build --all-targets` successfully.
- [x] I've run the unit tests `cargo test --workspace` and everything passes.
- [x] I've made sure my rust toolchain is current `rustup update`.
