### PR TITLE
use workflow identity instead of keys

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,6 +52,9 @@ jobs:
         cargo test --workspace --verbose --release
 
   build-push-linux:
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     runs-on: ubuntu-latest
     env:
       RUSTC_WRAPPER: /home/runner/.cargo/bin/sccache
@@ -113,7 +116,8 @@ jobs:
       if: github.repository_owner == 'pyrsia' && (github.event_name == 'push' || github.event_name == 'release')  
       uses: 'google-github-actions/auth@v0'
       with:
-        credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
+        workload_identity_provider: 'projects/679352079717/locations/global/workloadIdentityPools/pyrsia-pool/providers/github-provider'
+        service_account: 'pyrsia-ghaction@pyrsia-sandbox.iam.gserviceaccount.com'  
 
     # Add gsutils
     - name: Set up Cloud SDK


### PR DESCRIPTION
<!--

Thank you for participating with our effort to build a more secure software supply chain.
Before submitting your Pull Request, please go over our check list.

-->

## Description

<!--

Try to fill in the following to help the reviewers dive into the pull request.
Explain the context and what changed.

-->

Fixes pyrsia/pyrsia#784

This PR updates the rust workflow to use the Google Workflow Identity to execute the gcloud auth instead of using the managed keys.

## Screenshots (optional)

## PR Checklist

<!-- Make certain you've done the following. -->

- [X] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [X] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/get_involved/good_pr.md)
- [X] I've included a good title and brief description along with how to review them.
- [X] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).

### Code Contributions

<!--

This section applies to code modifications, you may remove it otherwise.

Make sure your Pull Request will pass the CI/CD pipeline.
For a complete list of steps, check out the [developer workflow](https://github.com/pyrsia/pyrsia/blob/main/docs/get_involved/dev_workflow.md)!

-->

- [X] I've built the code `cargo build --all-targets` successfully.
- [X] I've run the unit tests `cargo test --workspace` and everything passes.
- [X] I've made sure my rust toolchain is current `rustup update`.
