### PR TITLE
Replace assay tests with regular tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,7 +644,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2913470204e9e8498a0f31f17f90a0de801ae92c8c5ac18c49af4819e6786697"
 dependencies = [
- "directories 2.0.2",
+ "directories",
  "serde",
  "toml",
 ]
@@ -991,15 +991,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "551a778172a450d7fc12e629ca3b0428d00f6afa9a43da1b630d54604e97371c"
 dependencies = [
  "cfg-if 0.1.10",
- "dirs-sys",
-]
-
-[[package]]
-name = "directories"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
-dependencies = [
  "dirs-sys",
 ]
 
@@ -3308,7 +3299,6 @@ name = "pyrsia"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "assay",
  "async-trait",
  "base64",
  "bincode",
@@ -3320,7 +3310,6 @@ dependencies = [
  "ctor",
  "defaults",
  "derive_builder",
- "directories 4.0.1",
  "dirs",
  "env_logger 0.9.0",
  "error-chain",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,6 @@ stringreader = "0.1.1"
 strum = "0.24.0"
 strum_macros = "0.24.0"
 sysinfo = "0.24.2"
-tempfile = "3.2.0"
 test-log = "0.2.8"
 thiserror = "1.0.31"
 tokio = { version = "1.19.2", features = [ "macros", "rt-multi-thread", "io-std" ] }
@@ -78,11 +77,10 @@ default-features = false
 features = []
 
 [dev-dependencies]
-assay = "0.1.1"
 string_manipulation = {path="tests/string_manipulation"}
+tempfile = "3.2.0"
 time = { version = "0.3.10", features = ["formatting", "parsing"] }
 tokio-test = "0.4.2"
-directories = "^4.0"
 
 [workspace]
 members = [

--- a/pyrsia_node/src/main.rs
+++ b/pyrsia_node/src/main.rs
@@ -20,7 +20,7 @@ pub mod network;
 use anyhow::{bail, Result};
 use args::parser::PyrsiaNodeArgs;
 use network::handlers;
-use pyrsia::artifact_service::storage::ArtifactStorage;
+use pyrsia::artifact_service::storage::{ArtifactStorage, ARTIFACTS_DIR};
 use pyrsia::docker::error_util::*;
 use pyrsia::docker::v2::routes::make_docker_routes;
 use pyrsia::logging::*;
@@ -37,6 +37,7 @@ use futures::StreamExt;
 use log::{debug, info, warn};
 use std::error::Error;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::path::PathBuf;
 use std::sync::Arc;
 use warp::Filter;
 
@@ -48,13 +49,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let args = PyrsiaNodeArgs::parse();
 
     debug!("Create transparency log");
-    let transparency_log = TransparencyLog::new();
+    let transparency_log = TransparencyLog::new(PathBuf::from(ARTIFACTS_DIR.as_str()))?;
 
     debug!("Create p2p components");
     let (p2p_client, mut p2p_events, event_loop) = p2p::setup_libp2p_swarm(args.max_provided_keys)?;
 
     debug!("Create artifact storage");
-    let artifact_storage = ArtifactStorage::new()?;
+    let artifact_storage = ArtifactStorage::new(PathBuf::from(ARTIFACTS_DIR.as_str()))?;
 
     debug!("Create blockchain components");
     let _blockchain = setup_blockchain()?;

--- a/src/blockchain/examples/simple_node.rs
+++ b/src/blockchain/examples/simple_node.rs
@@ -273,7 +273,7 @@ mod tests {
             key_filename: DEFAULT_BLOCK_KEYPAIR_FILENAME.to_string(),
             peer_index: 0,
         };
-        let result = std::panic::catch_unwind(|| create_ed25519_keypair(args));
+        let result = std::panic::catch_unwind(|| create_ed25519_keypair(get_keyfile_name(args)));
         assert!(result.is_ok());
     }
 }

--- a/src/docker/v2/handlers/blobs.rs
+++ b/src/docker/v2/handlers/blobs.rs
@@ -63,7 +63,6 @@ mod tests {
     use crate::artifact_service::service::{Hash, HashAlgorithm};
     use crate::util::test_util;
     use anyhow::Context;
-    use assay::assay;
     use futures::channel::mpsc;
     use hyper::header::HeaderValue;
     use libp2p::identity::Keypair;
@@ -87,23 +86,19 @@ mod tests {
         );
     }
 
-    #[assay(
-        env = [
-          ("PYRSIA_ARTIFACT_PATH", "pyrsia-test-node"),
-          ("DEV_MODE", "on")
-        ],
-        teardown = test_util::tear_down()
-    )]
     #[tokio::test]
     async fn test_handle_get_blobs_unknown_in_artifact_service() {
+        let tmp_dir = test_util::tests::setup();
+
         let hash = "7300a197d7deb39371d4683d60f60f2fbbfd7541837ceb2278c12014e94e657b";
         let namespace_specific_id = format!("DOCKER::BLOB::{}", hash);
 
-        let transparency_log = Arc::new(Mutex::new(TransparencyLog::new()));
+        let transparency_log = Arc::new(Mutex::new(TransparencyLog::new(&tmp_dir).unwrap()));
         transparency_log
             .lock()
             .await
-            .add_artifact(&namespace_specific_id, hash)?;
+            .add_artifact(&namespace_specific_id, hash)
+            .unwrap();
 
         let (sender, _) = mpsc::channel(1);
         let p2p_client = Client {
@@ -111,7 +106,7 @@ mod tests {
             local_peer_id: Keypair::generate_ed25519().public().to_peer_id(),
         };
 
-        let artifact_storage = ArtifactStorage::new()?;
+        let artifact_storage = ArtifactStorage::new(&tmp_dir).unwrap();
 
         let result = handle_get_blobs(
             transparency_log,
@@ -130,25 +125,23 @@ mod tests {
                 code: RegistryErrorCode::BlobUnknown,
             }
         );
+
+        test_util::tests::teardown(tmp_dir);
     }
 
-    #[assay(
-        env = [
-          ("PYRSIA_ARTIFACT_PATH", "pyrsia-test-node"),
-          ("DEV_MODE", "on")
-        ],
-        teardown = test_util::tear_down()
-    )]
     #[tokio::test]
     async fn test_handle_get_blobs() {
+        let tmp_dir = test_util::tests::setup();
+
         let hash = "865c8d988be4669f3e48f73b98f9bc2507be0246ea35e0098cf6054d3644c14f";
         let namespace_specific_id = format!("DOCKER::BLOB::{}", hash);
 
-        let transparency_log = Arc::new(Mutex::new(TransparencyLog::new()));
+        let transparency_log = Arc::new(Mutex::new(TransparencyLog::new(&tmp_dir).unwrap()));
         transparency_log
             .lock()
             .await
-            .add_artifact(&namespace_specific_id, hash)?;
+            .add_artifact(&namespace_specific_id, hash)
+            .unwrap();
 
         let (sender, _) = mpsc::channel(1);
         let p2p_client = Client {
@@ -156,8 +149,8 @@ mod tests {
             local_peer_id: Keypair::generate_ed25519().public().to_peer_id(),
         };
 
-        let artifact_storage = ArtifactStorage::new()?;
-        create_artifact(&artifact_storage)?;
+        let artifact_storage = ArtifactStorage::new(&tmp_dir).unwrap();
+        create_artifact(&artifact_storage).unwrap();
 
         let result = handle_get_blobs(
             transparency_log,
@@ -175,6 +168,8 @@ mod tests {
             response.headers().get("Content-Type"),
             Some(&HeaderValue::from_static("application/octet-stream"))
         );
+
+        test_util::tests::teardown(tmp_dir);
     }
 
     fn get_file_reader() -> Result<File, anyhow::Error> {

--- a/src/docker/v2/handlers/manifests.rs
+++ b/src/docker/v2/handlers/manifests.rs
@@ -71,7 +71,6 @@ mod tests {
     use crate::artifact_service::service::{Hash, HashAlgorithm};
     use crate::util::test_util;
     use anyhow::Context;
-    use assay::assay;
     use futures::channel::mpsc;
     use hyper::header::HeaderValue;
     use libp2p::identity::Keypair;
@@ -96,25 +95,21 @@ mod tests {
         );
     }
 
-    #[assay(
-        env = [
-          ("PYRSIA_ARTIFACT_PATH", "pyrsia-test-node"),
-          ("DEV_MODE", "on")
-        ],
-        teardown = test_util::tear_down()
-    )]
     #[tokio::test]
     async fn test_fetch_manifest_unknown_in_artifact_service() {
+        let tmp_dir = test_util::tests::setup();
+
         let name = "name";
         let tag = "tag";
         let hash = "7300a197d7deb39371d4683d60f60f2fbbfd7541837ceb2278c12014e94e657b";
         let namespace_specific_id = format!("DOCKER::MANIFEST::{}::{}", name, tag);
 
-        let transparency_log = Arc::new(Mutex::new(TransparencyLog::new()));
+        let transparency_log = Arc::new(Mutex::new(TransparencyLog::new(&tmp_dir).unwrap()));
         transparency_log
             .lock()
             .await
-            .add_artifact(&namespace_specific_id, hash)?;
+            .add_artifact(&namespace_specific_id, hash)
+            .unwrap();
 
         let (sender, _) = mpsc::channel(1);
         let p2p_client = Client {
@@ -122,7 +117,7 @@ mod tests {
             local_peer_id: Keypair::generate_ed25519().public().to_peer_id(),
         };
 
-        let artifact_storage = ArtifactStorage::new()?;
+        let artifact_storage = ArtifactStorage::new(&tmp_dir).unwrap();
 
         let result = fetch_manifest(
             transparency_log,
@@ -142,27 +137,25 @@ mod tests {
                 code: RegistryErrorCode::ManifestUnknown,
             }
         );
+
+        test_util::tests::teardown(tmp_dir);
     }
 
-    #[assay(
-        env = [
-          ("PYRSIA_ARTIFACT_PATH", "pyrsia-test-node"),
-          ("DEV_MODE", "on")
-        ],
-        teardown = test_util::tear_down()
-    )]
     #[tokio::test]
     async fn test_fetch_manifest() {
+        let tmp_dir = test_util::tests::setup();
+
         let name = "name";
         let tag = "tag";
         let hash = "865c8d988be4669f3e48f73b98f9bc2507be0246ea35e0098cf6054d3644c14f";
         let namespace_specific_id = format!("DOCKER::MANIFEST::{}::{}", name, tag);
 
-        let transparency_log = Arc::new(Mutex::new(TransparencyLog::new()));
+        let transparency_log = Arc::new(Mutex::new(TransparencyLog::new(&tmp_dir).unwrap()));
         transparency_log
             .lock()
             .await
-            .add_artifact(&namespace_specific_id, hash)?;
+            .add_artifact(&namespace_specific_id, hash)
+            .unwrap();
 
         let (sender, _) = mpsc::channel(1);
         let p2p_client = Client {
@@ -170,8 +163,8 @@ mod tests {
             local_peer_id: Keypair::generate_ed25519().public().to_peer_id(),
         };
 
-        let artifact_storage = ArtifactStorage::new()?;
-        create_artifact(&artifact_storage)?;
+        let artifact_storage = ArtifactStorage::new(&tmp_dir).unwrap();
+        create_artifact(&artifact_storage).unwrap();
 
         let result = fetch_manifest(
             transparency_log,
@@ -196,6 +189,8 @@ mod tests {
                 "application/vnd.docker.distribution.manifest.v2+json"
             ))
         );
+
+        test_util::tests::teardown(tmp_dir);
     }
 
     fn get_file_reader() -> Result<File, anyhow::Error> {

--- a/src/util/env_util.rs
+++ b/src/util/env_util.rs
@@ -33,34 +33,36 @@ pub fn read_var(variable_name: &str, default_value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use assay::assay;
 
-    #[assay(
-        env = [
-          ("DEV_MODE", "on")
-        ],)]
+    #[test]
     fn test_value_present() {
-        assert_eq!("on", read_var("DEV_MODE", "off"));
+        env::set_var("ENV_VAR_PRESENT", "on");
+
+        assert_eq!("on", read_var("ENV_VAR_PRESENT", "off"));
+
+        env::remove_var("ENV_VAR_PRESENT");
     }
 
-    #[assay(
-        env = [
-          ("DEV_MODE", "on ")
-        ],)]
+    #[test]
     fn test_value_present_trim() {
-        assert_eq!("on", read_var("DEV_MODE", "off"));
+        env::set_var("ENV_VAR_PRESENT_TRIM", "on ");
+
+        assert_eq!("on", read_var("ENV_VAR_PRESENT_TRIM", "off"));
+
+        env::remove_var("ENV_VAR_PRESENT_TRIM");
     }
 
-    #[assay(
-        env = [
-            ("DEV_MODE", "")
-        ],)]
+    #[test]
     fn test_value_empty() {
-        assert_eq!("off", read_var("DEV_MODE", "off"));
+        env::set_var("ENV_VAR_EMPTY", "");
+
+        assert_eq!("off", read_var("ENV_VAR_EMPTY", "off"));
+
+        env::remove_var("ENV_VAR_EMPTY");
     }
 
-    #[assay]
+    #[test]
     fn test_value_absent() {
-        assert_eq!("absent", read_var("DEV_MODE", "absent"));
+        assert_eq!("absent", read_var("ENV_VAR_ABSENT", "absent"));
     }
 }

--- a/src/util/keypair_util.rs
+++ b/src/util/keypair_util.rs
@@ -96,7 +96,7 @@ mod tests {
     #[test]
     fn load_existing_keypair_with_wrong_size_fails() {
         let tmp_file = tempfile::Builder::new().tempfile().unwrap();
-        tmp_file.as_file().write_all(&vec![1; 32]).unwrap();
+        tmp_file.as_file().write_all(&[1; 32]).unwrap();
 
         let keypair = load_ed25519(tmp_file.path().to_str().unwrap());
         assert!(keypair.is_err());
@@ -105,7 +105,7 @@ mod tests {
     #[test]
     fn load_existing_keypair_succeeds() {
         let tmp_file = tempfile::Builder::new().tempfile().unwrap();
-        tmp_file.as_file().write_all(&vec![1; 64]).unwrap();
+        tmp_file.as_file().write_all(&[1; 64]).unwrap();
 
         let keypair = load_ed25519(tmp_file.path().to_str().unwrap());
         assert!(keypair.is_ok());

--- a/src/util/test_util.rs
+++ b/src/util/test_util.rs
@@ -15,11 +15,29 @@
 */
 
 #[cfg(test)]
-pub fn tear_down() {
-    if std::path::Path::new(&std::env::var("PYRSIA_ARTIFACT_PATH").unwrap()).exists() {
-        std::fs::remove_dir_all(std::env::var("PYRSIA_ARTIFACT_PATH").unwrap()).expect(&format!(
-            "unable to remove test directory {}",
-            std::env::var("PYRSIA_ARTIFACT_PATH").unwrap()
-        ));
+pub mod tests {
+    use std::env;
+    use std::fs;
+    use std::path;
+
+    pub fn setup() -> path::PathBuf {
+        let tmp_dir = tempfile::tempdir()
+            .expect("could not create temporary directory")
+            .into_path();
+
+        env::set_var("PYRSIA_ARTIFACT_PATH", tmp_dir.to_str().unwrap());
+        env::set_var("DEV_MODE", "on");
+
+        tmp_dir
+    }
+
+    pub fn teardown(tmp_dir: path::PathBuf) {
+        if tmp_dir.exists() {
+            fs::remove_dir_all(&tmp_dir)
+                .unwrap_or_else(|_| panic!("unable to remove test directory {:?}", tmp_dir));
+        }
+
+        env::remove_var("PYRSIA_ARTIFACT_PATH");
+        env::remove_var("DEV_MODE");
     }
 }


### PR DESCRIPTION
## Description

Fixes pyrsia/pyrsia#773

When using the assay crate, those tests that use it won't be seen by the tarpaulin coverage tool. This is because assay will spawn a child process in which the actual test is run. This PR removes the usage of assay replacing it with the regular rust test framework.

## PR Checklist

<!-- Make certain you've done the following. -->

- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/get_involved/good_pr.md)
- [x] I've included a good title and brief description along with how to review them.
- [x] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).

### Code Contributions

<!--

This section applies to code modifications, you may remove it otherwise.

Make sure your Pull Request will pass the CI/CD pipeline.
For a complete list of steps, check out the [developer workflow](https://github.com/pyrsia/pyrsia/blob/main/docs/get_involved/dev_workflow.md)!

-->

- [x] I've built the code `cargo build --all-targets` successfully.
- [x] I've run the unit tests `cargo test --workspace` and everything passes.
- [x] I've made sure my rust toolchain is current `rustup update`.
