### PR TITLE
make keypair name and location configurable

### DIFF
--- a/pyrsia_node/src/main.rs
+++ b/pyrsia_node/src/main.rs
@@ -32,6 +32,7 @@ use pyrsia::network::client::Client;
 use pyrsia::network::p2p;
 use pyrsia::node_api::routes::make_node_routes;
 use pyrsia::util::keypair_util;
+use pyrsia::util::keypair_util::KEYPAIR_FILENAME;
 use pyrsia_blockchain_network::blockchain::Blockchain;
 
 use clap::Parser;

--- a/pyrsia_node/src/main.rs
+++ b/pyrsia_node/src/main.rs
@@ -130,7 +130,7 @@ async fn setup_p2p(mut p2p_client: Client, args: &PyrsiaNodeArgs) -> Result<()> 
 
 fn setup_blockchain() -> Result<Arc<Mutex<Blockchain>>> {
     let local_keypair =
-        keypair_util::load_or_generate_ed25519(PathBuf::from(ARTIFACTS_DIR.as_str()));
+        keypair_util::load_or_generate_ed25519(PathBuf::from(KEYPAIR_FILENAME.as_str()));
 
     let ed25519_keypair = match local_keypair {
         libp2p::identity::Keypair::Ed25519(v) => v,

--- a/src/network/p2p.rs
+++ b/src/network/p2p.rs
@@ -14,7 +14,6 @@
    limitations under the License.
 */
 
-use crate::artifact_service::storage::ARTIFACTS_DIR;
 use crate::network::artifact_protocol::{ArtifactExchangeCodec, ArtifactExchangeProtocol};
 use crate::network::behaviour::PyrsiaNetworkBehaviour;
 use crate::network::blockchain_protocol::{BlockUpdateExchangeCodec, BlockUpdateExchangeProtocol};
@@ -22,6 +21,7 @@ use crate::network::client::Client;
 use crate::network::event_loop::{PyrsiaEvent, PyrsiaEventLoop};
 use crate::network::idle_metric_protocol::{IdleMetricExchangeCodec, IdleMetricExchangeProtocol};
 use crate::util::keypair_util;
+use crate::util::keypair_util::KEYPAIR_FILENAME;
 
 use libp2p::core;
 use libp2p::dns;
@@ -38,7 +38,6 @@ use libp2p::yamux;
 use libp2p::Transport;
 use std::error::Error;
 use std::iter;
-use std::path::PathBuf;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_stream::Stream;
@@ -110,8 +109,7 @@ use tokio_stream::Stream;
 pub fn setup_libp2p_swarm(
     max_provided_keys: usize,
 ) -> Result<(Client, impl Stream<Item = PyrsiaEvent>, PyrsiaEventLoop), Box<dyn Error>> {
-    let local_keypair =
-        keypair_util::load_or_generate_ed25519(PathBuf::from(ARTIFACTS_DIR.as_str()));
+    let local_keypair = keypair_util::load_or_generate_ed25519(KEYPAIR_FILENAME.as_str());
 
     let (swarm, local_peer_id) = create_swarm(local_keypair, max_provided_keys)?;
 


### PR DESCRIPTION
<!--

Thank you for participating with our effort to build a more secure software supply chain.
Before submitting your Pull Request, please go over our check list.

-->

## Description

Make the location of the key pair configurable so it is not in the artifact directory.

<!--

Try to fill in the following to help the reviewers dive into the pull request.
Explain the context and what changed.

-->

Fixes #831 

This PR makes the key pair configurable by using PYRSIA_KEYPAIR env var. This env var is the full file name for the key pair.  A new key pair will be generated if one does not exist.

## Screenshots (optional)

## PR Checklist

<!-- Make certain you've done the following. -->

- [X] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [X] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/get_involved/good_pr.md)
- [X] I've included a good title and brief description along with how to review them.
- [X] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).

### Code Contributions

<!--

This section applies to code modifications, you may remove it otherwise.

Make sure your Pull Request will pass the CI/CD pipeline.
For a complete list of steps, check out the [developer workflow](https://github.com/pyrsia/pyrsia/blob/main/docs/get_involved/dev_workflow.md)!

-->

- [X] I've built the code `cargo build --all-targets` successfully.
- [X] I've run the unit tests `cargo test --workspace` and everything passes.
- [X] I've made sure my rust toolchain is current `rustup update`.
