### PR TITLE
End-to-end integration for build from source

### DIFF
--- a/pyrsia_node/src/main.rs
+++ b/pyrsia_node/src/main.rs
@@ -62,10 +62,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     debug!("Create pyrsia services");
     let artifact_service = setup_pyrsia_services(p2p_client.clone(), &args)?;
-    // let artifact_service = setup_artifact_service(p2p_client.clone(), &args)?;
-
-    // debug!("Create build service");
-    // let build_service = setup_build_service(p2p_client.clone(), &args)?;
 
     debug!("Start p2p components");
     setup_p2p(p2p_client.clone(), &args).await?;
@@ -145,6 +141,7 @@ fn setup_pyrsia_services(
     debug!("Create build service");
     let build_service = setup_build_service(&artifact_path, build_event_sender, args)?;
 
+    debug!("Start build event loop");
     let build_event_loop = BuildEventLoop::new(
         artifact_service.clone(),
         build_service.clone(),

--- a/pyrsia_node/src/main.rs
+++ b/pyrsia_node/src/main.rs
@@ -22,6 +22,7 @@ use args::parser::PyrsiaNodeArgs;
 use network::handlers;
 use pyrsia::artifact_service::service::ArtifactService;
 use pyrsia::artifact_service::storage::ARTIFACTS_DIR;
+use pyrsia::build_service::event::{BuildEvent, BuildEventLoop};
 use pyrsia::build_service::service::BuildService;
 use pyrsia::docker::error_util::*;
 use pyrsia::docker::v2::routes::make_docker_routes;
@@ -37,9 +38,9 @@ use clap::Parser;
 use log::{debug, info, warn};
 use std::error::Error;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use tokio::sync::Mutex;
+use tokio::sync::{mpsc, Mutex};
 use tokio_stream::StreamExt;
 use warp::Filter;
 
@@ -53,17 +54,18 @@ async fn main() -> Result<(), Box<dyn Error>> {
     debug!("Create p2p components");
     let (p2p_client, mut p2p_events, event_loop) = p2p::setup_libp2p_swarm(args.max_provided_keys)?;
 
-    debug!("Create artifact service");
-    let artifact_service = setup_artifact_service(p2p_client.clone(), &args)?;
-
     debug!("Create blockchain components");
     let _blockchain = setup_blockchain()?;
 
     debug!("Start p2p event loop");
     tokio::spawn(event_loop.run());
 
-    debug!("Setup HTTP server");
-    setup_http(&args, artifact_service.clone());
+    debug!("Create pyrsia services");
+    let artifact_service = setup_pyrsia_services(p2p_client.clone(), &args)?;
+    // let artifact_service = setup_artifact_service(p2p_client.clone(), &args)?;
+
+    // debug!("Create build service");
+    // let build_service = setup_build_service(p2p_client.clone(), &args)?;
 
     debug!("Start p2p components");
     setup_p2p(p2p_client.clone(), &args).await?;
@@ -105,7 +107,87 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
 }
 
-fn setup_http(args: &PyrsiaNodeArgs, artifact_service: Arc<Mutex<ArtifactService>>) {
+async fn setup_p2p(mut p2p_client: Client, args: &PyrsiaNodeArgs) -> Result<()> {
+    p2p_client.listen(&args.listen_address).await?;
+
+    if let Some(to_dial) = &args.peer {
+        handlers::dial_other_peer(p2p_client.clone(), to_dial).await
+    } else {
+        Ok(())
+    }
+}
+
+fn setup_blockchain() -> Result<Arc<Mutex<Blockchain>>> {
+    let local_keypair =
+        keypair_util::load_or_generate_ed25519(PathBuf::from(ARTIFACTS_DIR.as_str()));
+
+    let ed25519_keypair = match local_keypair {
+        libp2p::identity::Keypair::Ed25519(v) => v,
+        _ => {
+            bail!("Keypair Format Error");
+        }
+    };
+
+    Ok(Arc::new(Mutex::new(Blockchain::new(&ed25519_keypair))))
+}
+
+fn setup_pyrsia_services(
+    p2p_client: Client,
+    args: &PyrsiaNodeArgs,
+) -> Result<Arc<Mutex<ArtifactService>>> {
+    let artifact_path = PathBuf::from(ARTIFACTS_DIR.as_str());
+    let (build_event_sender, build_event_receiver) = mpsc::channel(32);
+
+    debug!("Create artifact service");
+    let artifact_service =
+        setup_artifact_service(&artifact_path, build_event_sender.clone(), p2p_client)?;
+
+    debug!("Create build service");
+    let build_service = setup_build_service(&artifact_path, build_event_sender, args)?;
+
+    let build_event_loop = BuildEventLoop::new(
+        artifact_service.clone(),
+        build_service.clone(),
+        build_event_receiver,
+    );
+    tokio::spawn(build_event_loop.run());
+
+    debug!("Setup HTTP server");
+    setup_http(args, artifact_service.clone(), build_service);
+
+    Ok(artifact_service)
+}
+
+fn setup_artifact_service(
+    artifact_path: &Path,
+    build_event_sender: mpsc::Sender<BuildEvent>,
+    p2p_client: Client,
+) -> Result<Arc<Mutex<ArtifactService>>> {
+    let artifact_service = ArtifactService::new(artifact_path, build_event_sender, p2p_client)?;
+
+    Ok(Arc::new(Mutex::new(artifact_service)))
+}
+
+fn setup_build_service(
+    artifact_path: &Path,
+    build_event_sender: mpsc::Sender<BuildEvent>,
+    args: &PyrsiaNodeArgs,
+) -> Result<Arc<Mutex<BuildService>>> {
+    let build_service = BuildService::new(
+        &artifact_path,
+        build_event_sender,
+        &args.mapping_service_endpoint,
+        &args.pipeline_service_endpoint,
+    )?;
+
+    Ok(Arc::new(Mutex::new(build_service)))
+}
+
+fn setup_http(
+    args: &PyrsiaNodeArgs,
+    artifact_service: Arc<Mutex<ArtifactService>>,
+    build_service: Arc<Mutex<BuildService>>,
+) {
     // Get host and port from the settings. Defaults to DEFAULT_HOST and DEFAULT_PORT
     debug!(
         "Pyrsia Docker Node will bind to host = {}, port = {}",
@@ -120,7 +202,7 @@ fn setup_http(args: &PyrsiaNodeArgs, artifact_service: Arc<Mutex<ArtifactService
     debug!("Setup HTTP routing");
     let docker_routes = make_docker_routes(artifact_service.clone());
     let maven_routes = make_maven_routes(artifact_service.clone());
-    let node_api_routes = make_node_routes(artifact_service);
+    let node_api_routes = make_node_routes(artifact_service, build_service);
     let all_routes = docker_routes.or(maven_routes).or(node_api_routes);
 
     debug!("Setup HTTP server");
@@ -139,46 +221,6 @@ fn setup_http(args: &PyrsiaNodeArgs, artifact_service: Arc<Mutex<ArtifactService
     );
 
     tokio::spawn(server);
-}
-
-async fn setup_p2p(mut p2p_client: Client, args: &PyrsiaNodeArgs) -> Result<()> {
-    p2p_client.listen(&args.listen_address).await?;
-
-    if let Some(to_dial) = &args.peer {
-        handlers::dial_other_peer(p2p_client.clone(), to_dial).await
-    } else {
-        Ok(())
-    }
-}
-
-fn setup_artifact_service(
-    p2p_client: Client,
-    args: &PyrsiaNodeArgs,
-) -> Result<Arc<Mutex<ArtifactService>>> {
-    let artifact_path = PathBuf::from(ARTIFACTS_DIR.as_str());
-    let build_service = BuildService::new(
-        &artifact_path,
-        &args.mapping_service_endpoint,
-        &args.pipeline_service_endpoint,
-    )?;
-
-    let artifact_service = ArtifactService::new(artifact_path, p2p_client, build_service)?;
-
-    Ok(Arc::new(Mutex::new(artifact_service)))
-}
-
-fn setup_blockchain() -> Result<Arc<Mutex<Blockchain>>> {
-    let local_keypair =
-        keypair_util::load_or_generate_ed25519(PathBuf::from(ARTIFACTS_DIR.as_str()));
-
-    let ed25519_keypair = match local_keypair {
-        libp2p::identity::Keypair::Ed25519(v) => v,
-        _ => {
-            bail!("Keypair Format Error");
-        }
-    };
-
-    Ok(Arc::new(Mutex::new(Blockchain::new(&ed25519_keypair))))
 }
 
 #[cfg(test)]

--- a/pyrsia_node/src/network/handlers.rs
+++ b/pyrsia_node/src/network/handlers.rs
@@ -47,7 +47,7 @@ pub async fn handle_request_artifact(
     debug!("Handling request artifact: {:?}", artifact_id);
 
     let mut artifact_service = artifact_service.lock().await;
-    let content = artifact_service.get_artifact_locally(artifact_id)?;
+    let content = artifact_service.get_artifact_locally(artifact_id).await?;
 
     artifact_service
         .p2p_client

--- a/src/artifact_service/service.rs
+++ b/src/artifact_service/service.rs
@@ -134,8 +134,7 @@ impl ArtifactService {
         self.put_artifact(artifact_id, &mut artifact_reader)
     }
 
-    /// Given artifact_id & reader, push artifact to artifact_manager
-    /// and returns the boolean as true or false if it was able to create or not
+    /// Given artifact_id & reader, push artifact to artifact_storage
     fn put_artifact(&self, artifact_id: &str, reader: &mut impl Read) -> Result<(), anyhow::Error> {
         info!("put_artifact with id: {}", artifact_id);
         self.artifact_storage
@@ -189,7 +188,7 @@ impl ArtifactService {
     ) -> Result<Vec<u8>, anyhow::Error> {
         let providers = self.p2p_client.list_providers(artifact_id).await?;
 
-        match self.p2p_client.clone().get_idle_peer(providers).await? {
+        match self.p2p_client.get_idle_peer(providers).await? {
             Some(peer_id) => self.get_artifact_from_peer(&peer_id, artifact_id).await,
             None => {
                 bail!(

--- a/src/build_service.rs
+++ b/src/build_service.rs
@@ -15,6 +15,7 @@
 */
 
 pub mod error;
+pub mod event;
 pub mod mapping;
 pub mod model;
 pub mod pipeline;

--- a/src/build_service/error.rs
+++ b/src/build_service/error.rs
@@ -20,8 +20,8 @@ use thiserror::Error;
 
 #[derive(Debug, Error, PartialEq)]
 pub enum BuildError {
-    #[error("Build failed: {0}")]
-    Failure(String),
+    #[error("Build with ID {0} failed with error: {1}")]
+    Failure(String, String),
     #[error("Invalid response from mapping service endpoint: {0}")]
     InvalidMappingResponse(String),
     #[error("Invalid response from pipeline service endpoint: {0}")]

--- a/src/build_service/event.rs
+++ b/src/build_service/event.rs
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021 JFrog Ltd
+   Copyright 2022 JFrog Ltd
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/build_service/event.rs
+++ b/src/build_service/event.rs
@@ -18,10 +18,11 @@ use crate::artifact_service::service::ArtifactService;
 use crate::build_service::error::BuildError;
 use crate::build_service::model::BuildResult;
 use crate::build_service::service::BuildService;
-use log::{error, warn};
+use log::{debug, error, warn};
 use std::sync::Arc;
 use tokio::sync::{mpsc, Mutex};
 
+#[derive(Debug)]
 pub enum BuildEvent {
     BuildCleanup {
         build_id: String,
@@ -69,6 +70,7 @@ impl BuildEventLoop {
     }
 
     async fn handle_build_event(&self, build_event: BuildEvent) {
+        debug!("Handle BuildEvent: {:?}", build_event);
         match build_event {
             BuildEvent::BuildCleanup { build_id } => {
                 self.build_service.lock().await.cleanup_build(&build_id);

--- a/src/build_service/event.rs
+++ b/src/build_service/event.rs
@@ -1,0 +1,93 @@
+/*
+   Copyright 2021 JFrog Ltd
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+use crate::artifact_service::service::ArtifactService;
+use crate::build_service::error::BuildError;
+use crate::build_service::model::BuildResult;
+use crate::build_service::service::BuildService;
+use log::{error, warn};
+use std::sync::Arc;
+use tokio::sync::{mpsc, Mutex};
+
+pub enum BuildEvent {
+    BuildCleanup {
+        build_id: String,
+    },
+    BuildFailed {
+        build_id: String,
+        build_error: BuildError,
+    },
+    BuildSucceeded(BuildResult),
+}
+
+pub struct BuildEventLoop {
+    artifact_service: Arc<Mutex<ArtifactService>>,
+    build_service: Arc<Mutex<BuildService>>,
+    build_event_receiver: mpsc::Receiver<BuildEvent>,
+}
+
+impl BuildEventLoop {
+    pub fn new(
+        artifact_service: Arc<Mutex<ArtifactService>>,
+        build_service: Arc<Mutex<BuildService>>,
+        build_event_receiver: mpsc::Receiver<BuildEvent>,
+    ) -> Self {
+        Self {
+            artifact_service,
+            build_service,
+            build_event_receiver,
+        }
+    }
+
+    pub async fn run(mut self) {
+        loop {
+            tokio::select! {
+                next_build_event = self.build_event_receiver.recv() => match next_build_event {
+                    Some(build_event) => {
+                        self.handle_build_event(build_event).await;
+                    },
+                    None => {
+                        warn!("Got empty build event");
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    async fn handle_build_event(&self, build_event: BuildEvent) {
+        match build_event {
+            BuildEvent::BuildCleanup { build_id } => {
+                self.build_service.lock().await.cleanup_build(&build_id);
+            }
+            BuildEvent::BuildFailed {
+                build_id,
+                build_error,
+            } => {
+                error!("{}", build_error.to_string());
+
+                self.build_service.lock().await.cleanup_build(&build_id);
+            }
+            BuildEvent::BuildSucceeded(build_result) => {
+                self.artifact_service
+                    .lock()
+                    .await
+                    .handle_build_result(build_result)
+                    .await;
+            }
+        }
+    }
+}

--- a/src/build_service/mapping/service.rs
+++ b/src/build_service/mapping/service.rs
@@ -22,12 +22,17 @@ pub struct MappingService {
     mapping_service_endpoint: String,
 }
 
+fn remove_last_character(mut string: String) -> String {
+    string.pop();
+    string
+}
+
 impl MappingService {
     pub fn new(mapping_service_endpoint: &str) -> Self {
         MappingService {
             mapping_service_endpoint: match mapping_service_endpoint.ends_with('/') {
-                true => mapping_service_endpoint.to_owned(),
-                false => format!("{}/", mapping_service_endpoint),
+                true => remove_last_character(mapping_service_endpoint.to_owned()),
+                false => mapping_service_endpoint.to_owned(),
             },
         }
     }
@@ -59,7 +64,7 @@ impl MappingService {
         let version = package_specific_pieces[2];
 
         let remote_mapping_url = format!(
-            "{}Maven2/{}/{}/{}/{}-{}.mapping",
+            "{}/Maven2/{}/{}/{}/{}-{}.mapping",
             self.mapping_service_endpoint, group_id, artifact_id, version, artifact_id, version
         );
 
@@ -99,7 +104,7 @@ mod tests {
         let mapping_service = MappingService::new(mapping_service_endpoint);
         assert_eq!(
             mapping_service.mapping_service_endpoint,
-            mapping_service_endpoint
+            remove_last_character(mapping_service_endpoint.to_owned())
         );
     }
 
@@ -109,7 +114,7 @@ mod tests {
         let mapping_service = MappingService::new(mapping_service_endpoint);
         assert_eq!(
             mapping_service.mapping_service_endpoint,
-            format!("{}/", mapping_service_endpoint)
+            mapping_service_endpoint
         );
     }
 

--- a/src/build_service/model.rs
+++ b/src/build_service/model.rs
@@ -15,6 +15,9 @@
 */
 
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+use crate::artifact_service::model::PackageType;
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub enum BuildStatus {
@@ -29,4 +32,17 @@ pub struct BuildInfo {
     pub status: BuildStatus,
 }
 
-pub struct BuildResult {}
+#[derive(Debug)]
+pub struct BuildResultArtifact {
+    pub artifact_specific_id: String,
+    pub artifact_location: PathBuf,
+    pub artifact_hash: String,
+}
+
+#[derive(Debug)]
+pub struct BuildResult {
+    pub build_id: String,
+    pub package_type: PackageType,
+    pub package_specific_id: String,
+    pub artifacts: Vec<BuildResultArtifact>,
+}

--- a/src/build_service/pipeline/service.rs
+++ b/src/build_service/pipeline/service.rs
@@ -18,6 +18,7 @@ use crate::build_service::error::BuildError;
 use crate::build_service::mapping::model::MappingInfo;
 use crate::build_service::model::BuildInfo;
 
+#[derive(Clone)]
 pub struct PipelineService {
     http_client: reqwest::Client,
     pipeline_service_endpoint: String,

--- a/src/build_service/pipeline/service.rs
+++ b/src/build_service/pipeline/service.rs
@@ -24,19 +24,24 @@ pub struct PipelineService {
     pipeline_service_endpoint: String,
 }
 
+fn remove_last_character(mut string: String) -> String {
+    string.pop();
+    string
+}
+
 impl PipelineService {
     pub fn new(pipeline_service_endpoint: &str) -> Self {
         PipelineService {
             http_client: reqwest::Client::new(),
             pipeline_service_endpoint: match pipeline_service_endpoint.ends_with('/') {
-                true => pipeline_service_endpoint.to_owned(),
-                false => format!("{}/", pipeline_service_endpoint),
+                true => remove_last_character(pipeline_service_endpoint.to_owned()),
+                false => pipeline_service_endpoint.to_owned(),
             },
         }
     }
 
     pub async fn start_build(&self, mapping_info: MappingInfo) -> Result<BuildInfo, BuildError> {
-        let start_build_endpoint = format!("{}build", self.pipeline_service_endpoint);
+        let start_build_endpoint = format!("{}/build", self.pipeline_service_endpoint);
 
         let start_build_response = self
             .http_client
@@ -60,7 +65,7 @@ impl PipelineService {
 
     pub async fn get_build_status(&self, build_id: &str) -> Result<BuildInfo, BuildError> {
         let get_build_status_endpoint =
-            format!("{}build/{}", self.pipeline_service_endpoint, build_id);
+            format!("{}/build/{}", self.pipeline_service_endpoint, build_id);
 
         let get_build_status_response = self
             .http_client
@@ -119,7 +124,7 @@ mod tests {
         let pipeline_service = PipelineService::new(pipeline_service_endpoint);
         assert_eq!(
             pipeline_service.pipeline_service_endpoint,
-            pipeline_service_endpoint
+            remove_last_character(pipeline_service_endpoint.to_owned())
         );
     }
 
@@ -129,7 +134,7 @@ mod tests {
         let pipeline_service = PipelineService::new(pipeline_service_endpoint);
         assert_eq!(
             pipeline_service.pipeline_service_endpoint,
-            format!("{}/", pipeline_service_endpoint)
+            pipeline_service_endpoint
         );
     }
 
@@ -322,16 +327,13 @@ mod tests {
 
     #[tokio::test]
     async fn download_artifact() {
-        let artifact_url = "artifact.file";
+        let artifact_url = "/artifact.file";
         let artifact_bytes = bytes::Bytes::from("some_bytes");
 
         let http_server = Server::run();
         http_server.expect(
-            Expectation::matching(matchers::request::method_path(
-                "GET",
-                format!("/{}", artifact_url),
-            ))
-            .respond_with(responders::status_code(200).body(artifact_bytes.clone())),
+            Expectation::matching(matchers::request::method_path("GET", artifact_url))
+                .respond_with(responders::status_code(200).body(artifact_bytes.clone())),
         );
 
         let pipeline_service = PipelineService::new(&http_server.url("/").to_string());
@@ -345,15 +347,12 @@ mod tests {
 
     #[tokio::test]
     async fn download_artifact_server_error() {
-        let artifact_url = "artifact.file";
+        let artifact_url = "/artifact.file";
 
         let http_server = Server::run();
         http_server.expect(
-            Expectation::matching(matchers::request::method_path(
-                "GET",
-                format!("/{}", artifact_url),
-            ))
-            .respond_with(responders::status_code(400)),
+            Expectation::matching(matchers::request::method_path("GET", artifact_url))
+                .respond_with(responders::status_code(400)),
         );
 
         let pipeline_service = PipelineService::new(&http_server.url("/").to_string());
@@ -374,7 +373,7 @@ mod tests {
         let pipeline_service = PipelineService::new("");
 
         pipeline_service
-            .download_artifact("artifact.file")
+            .download_artifact("/artifact.file")
             .await
             .unwrap();
     }

--- a/src/build_service/service.rs
+++ b/src/build_service/service.rs
@@ -14,19 +14,25 @@
    limitations under the License.
 */
 
-use tokio::sync::oneshot;
-
 use super::error::BuildError;
+use super::event::BuildEvent;
 use super::mapping::service::MappingService;
-use super::model::{BuildInfo, BuildResult};
+use super::model::{BuildInfo, BuildResult, BuildResultArtifact, BuildStatus};
 use super::pipeline::service::PipelineService;
 use crate::artifact_service::model::PackageType;
+use bytes::Buf;
+use log::{debug, warn};
+use multihash::Hasher;
+use std::fs;
+use std::io;
 use std::path::{Path, PathBuf};
+use tokio::sync::mpsc;
 
 /// The build service is a component used by authorized nodes only. It is
 /// the entrypoint to the authorized node's build pipeline infrastructure.
 pub struct BuildService {
-    _repository_path: PathBuf,
+    repository_path: PathBuf,
+    build_event_sender: mpsc::Sender<BuildEvent>,
     mapping_service: MappingService,
     pipeline_service: PipelineService,
 }
@@ -34,12 +40,14 @@ pub struct BuildService {
 impl BuildService {
     pub fn new<P: AsRef<Path>>(
         repository_path: P,
+        build_event_sender: mpsc::Sender<BuildEvent>,
         mapping_service_endpoint: &str,
         pipeline_service_endpoint: &str,
     ) -> Result<Self, anyhow::Error> {
         let repository_path = repository_path.as_ref().to_path_buf().canonicalize()?;
         Ok(BuildService {
-            _repository_path: repository_path,
+            repository_path,
+            build_event_sender,
             mapping_service: MappingService::new(mapping_service_endpoint),
             pipeline_service: PipelineService::new(pipeline_service_endpoint),
         })
@@ -49,23 +57,166 @@ impl BuildService {
     pub async fn start_build(
         &self,
         package_type: PackageType,
-        package_specific_id: &str,
-        _sender: oneshot::Sender<Result<Vec<BuildResult>, BuildError>>,
+        package_specific_id: String,
     ) -> Result<BuildInfo, BuildError> {
+        debug!(
+            "Starting build for package type {:?} and specific ID {:}",
+            package_type, package_specific_id
+        );
+
         let mapping_info = self
             .mapping_service
-            .get_mapping(package_type, package_specific_id)
+            .get_mapping(package_type, &package_specific_id)
             .await?;
 
-        self.pipeline_service.start_build(mapping_info).await
+        let build_info = self.pipeline_service.start_build(mapping_info).await?;
+        if build_info.status == BuildStatus::Running {
+            let build_id = build_info.id.clone();
+            let build_path = self.get_build_path(&build_id);
+            let pipeline_service = self.pipeline_service.clone();
+            let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(5));
+            let build_event_sender = self.build_event_sender.clone();
+            tokio::spawn(async move {
+                loop {
+                    interval.tick().await;
+
+                    match pipeline_service.get_build_status(&build_id).await {
+                        Ok(latest_build_info) => {
+                            match latest_build_info.status {
+                                BuildStatus::Success { artifact_urls } => {
+                                    match handle_successful_build(
+                                        package_type,
+                                        &package_specific_id,
+                                        &build_path,
+                                        &pipeline_service,
+                                        &latest_build_info.id,
+                                        artifact_urls,
+                                    )
+                                    .await
+                                    {
+                                        Ok(build_result) => {
+                                            let _ = build_event_sender
+                                                .send(BuildEvent::BuildSucceeded(build_result));
+                                        }
+                                        Err(build_error) => {
+                                            let _ =
+                                                build_event_sender.send(BuildEvent::BuildFailed {
+                                                    build_id: build_id.clone(),
+                                                    build_error,
+                                                });
+                                        }
+                                    }
+                                    break;
+                                }
+                                BuildStatus::Failure(error) => {
+                                    let _ = build_event_sender.send(BuildEvent::BuildFailed {
+                                        build_id: build_id.clone(),
+                                        build_error: BuildError::Failure(
+                                            latest_build_info.id,
+                                            error,
+                                        ),
+                                    });
+                                    break;
+                                }
+                                _ => continue,
+                            };
+                        }
+                        Err(build_error) => {
+                            let _ = build_event_sender.send(BuildEvent::BuildFailed {
+                                build_id: build_id.clone(),
+                                build_error,
+                            });
+                        }
+                    }
+                }
+            });
+        }
+
+        Ok(build_info)
     }
+
+    pub fn cleanup_build(&self, build_id: &str) {
+        let build_path = self.get_build_path(build_id);
+        if let Err(error) = fs::remove_dir_all(&build_path) {
+            warn!(
+                "Could not remove temporary build directory {:?}. Failed with error: {:?}",
+                build_path, error
+            )
+        }
+    }
+
+    fn get_build_path(&self, build_id: &str) -> PathBuf {
+        self.repository_path.clone().join("builds").join(build_id)
+    }
+}
+
+async fn handle_successful_build(
+    package_type: PackageType,
+    package_specific_id: &str,
+    build_path: &Path,
+    pipeline_service: &PipelineService,
+    build_id: &str,
+    build_artifact_urls: Vec<String>,
+) -> Result<BuildResult, BuildError> {
+    let mut artifacts = vec![];
+
+    fs::create_dir_all(build_path)
+        .map_err(|e| BuildError::Failure(build_id.to_owned(), e.to_string()))?;
+
+    for build_artifact_url in build_artifact_urls {
+        let artifact = pipeline_service
+            .download_artifact(&build_artifact_url)
+            .await?;
+        let (artifact_location, artifact_hash) = hash_and_store_data(build_path, &artifact)
+            .map_err(|e| BuildError::Failure(build_id.to_owned(), e.to_string()))?;
+
+        let artifact_specific_id = match package_type {
+            PackageType::Docker => package_specific_id.to_owned(),
+            PackageType::Maven2 => {
+                let prefix = package_specific_id.replace(':', "/");
+                let build_artifact_filename = match build_artifact_url.rfind('/') {
+                    Some(position) => String::from(&build_artifact_url[position + 1..]),
+                    None => build_artifact_url,
+                };
+                format!("{}/{}", prefix, build_artifact_filename)
+            }
+        };
+
+        artifacts.push(BuildResultArtifact {
+            artifact_specific_id,
+            artifact_location,
+            artifact_hash,
+        });
+    }
+
+    Ok(BuildResult {
+        build_id: build_id.to_owned(),
+        package_type,
+        package_specific_id: package_specific_id.to_owned(),
+        artifacts,
+    })
+}
+
+fn hash_and_store_data(build_path: &Path, bytes: &[u8]) -> Result<(PathBuf, String), io::Error> {
+    let hash = calculate_hash(bytes);
+    let mut data_location = PathBuf::from(build_path);
+    data_location.push(&hash);
+    let mut file = fs::File::create(&data_location)?;
+    io::copy(&mut bytes.reader(), &mut file)?;
+
+    Ok((data_location, hash))
+}
+
+fn calculate_hash(bytes: &[u8]) -> String {
+    let mut sha256 = multihash::Sha2_256::default();
+    sha256.update(bytes);
+    hex::encode(sha256.finalize())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::build_service::mapping::model::MappingInfo;
-    use crate::build_service::model::BuildStatus;
     use crate::util::test_util;
     use httptest::{matchers, responders, Expectation, Server};
 
@@ -76,7 +227,7 @@ mod tests {
         let package_type = PackageType::Docker;
         let package_specific_id = "alpine:3.15.2";
 
-        let (sender, _) = oneshot::channel();
+        let (sender, _) = mpsc::channel(1);
 
         let mapping_info = MappingInfo {
             package_type: PackageType::Docker,
@@ -106,12 +257,13 @@ mod tests {
 
         let build_service = BuildService::new(
             &tmp_dir,
+            sender,
             mapping_service_endpoint,
             pipeline_service_endpoint,
         )
         .unwrap();
         let build_info_result = build_service
-            .start_build(package_type, package_specific_id, sender)
+            .start_build(package_type, package_specific_id.to_owned())
             .await
             .unwrap();
 

--- a/src/build_service/service.rs
+++ b/src/build_service/service.rs
@@ -82,6 +82,8 @@ impl BuildService {
 
                     match pipeline_service.get_build_status(&build_id).await {
                         Ok(latest_build_info) => {
+                            println!("Latest Build Info: {:?}", &latest_build_info);
+
                             match latest_build_info.status {
                                 BuildStatus::Success { artifact_urls } => {
                                     match handle_successful_build(

--- a/src/docker/error_util.rs
+++ b/src/docker/error_util.rs
@@ -210,8 +210,8 @@ mod tests {
 
     #[test]
     fn from_build_error() {
-        let build_error_1 = BuildError::Failure("Failed".to_owned());
-        let build_error_2 = BuildError::Failure("Failed".to_owned());
+        let build_error_1 = BuildError::Failure("build_id".to_owned(), "Failed".to_owned());
+        let build_error_2 = BuildError::Failure("build_id".to_owned(), "Failed".to_owned());
 
         let registry_error: RegistryError = build_error_1.into();
         assert_eq!(

--- a/src/docker/v2/handlers/blobs.rs
+++ b/src/docker/v2/handlers/blobs.rs
@@ -52,7 +52,6 @@ pub async fn handle_get_blobs(
 mod tests {
     use super::*;
     use crate::artifact_service::storage::ArtifactStorage;
-    use crate::build_service::service::BuildService;
     use crate::network::client::Client;
     use crate::transparency_log::log::AddArtifactRequest;
     use crate::util::test_util;
@@ -71,14 +70,14 @@ mod tests {
         let name = "alpine";
         let hash = "7300a197d7deb39371d4683d60f60f2fbbfd7541837ceb2278c12014e94e657b";
 
-        let (sender, _) = mpsc::channel(1);
+        let (command_sender, _command_receiver) = mpsc::channel(1);
         let p2p_client = Client {
-            sender,
+            sender: command_sender,
             local_peer_id: Keypair::generate_ed25519().public().to_peer_id(),
         };
 
-        let build_service = BuildService::new(&tmp_dir, "", "").unwrap();
-        let artifact_service = ArtifactService::new(&tmp_dir, p2p_client, build_service)
+        let (build_command_sender, _build_command_receiver) = mpsc::channel(1);
+        let artifact_service = ArtifactService::new(&tmp_dir, build_command_sender, p2p_client)
             .expect("Creating ArtifactService failed");
 
         let result = handle_get_blobs(
@@ -112,14 +111,14 @@ mod tests {
         let package_specific_artifact_id = hash;
 
         let (add_artifact_sender, add_artifact_receiver) = oneshot::channel();
-        let (sender, _) = mpsc::channel(1);
+        let (command_sender, _command_receiver) = mpsc::channel(1);
         let p2p_client = Client {
-            sender,
+            sender: command_sender,
             local_peer_id: Keypair::generate_ed25519().public().to_peer_id(),
         };
 
-        let build_service = BuildService::new(&tmp_dir, "", "").unwrap();
-        let mut artifact_service = ArtifactService::new(&tmp_dir, p2p_client, build_service)
+        let (build_command_sender, _build_command_receiver) = mpsc::channel(1);
+        let mut artifact_service = ArtifactService::new(&tmp_dir, build_command_sender, p2p_client)
             .expect("Creating ArtifactService failed");
 
         artifact_service
@@ -130,7 +129,6 @@ mod tests {
                     package_specific_id: package_specific_id.to_owned(),
                     package_specific_artifact_id: package_specific_artifact_id.to_owned(),
                     artifact_hash: hash.to_owned(),
-                    source_hash: hash.to_owned(),
                 },
                 add_artifact_sender,
             )

--- a/src/docker/v2/routes.rs
+++ b/src/docker/v2/routes.rs
@@ -59,7 +59,6 @@ pub fn make_docker_routes(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::build_service::service::BuildService;
     use crate::docker::error_util::{RegistryError, RegistryErrorCode};
     use crate::network::client::Client;
     use crate::util::test_util;
@@ -71,14 +70,14 @@ mod tests {
     async fn docker_routes_base() {
         let tmp_dir = test_util::tests::setup();
 
-        let (sender, _) = mpsc::channel(1);
+        let (command_sender, _command_receiver) = mpsc::channel(1);
         let p2p_client = Client {
-            sender,
+            sender: command_sender,
             local_peer_id: Keypair::generate_ed25519().public().to_peer_id(),
         };
 
-        let build_service = BuildService::new(&tmp_dir, "", "").unwrap();
-        let artifact_service = ArtifactService::new(&tmp_dir, p2p_client, build_service)
+        let (build_command_sender, _build_command_receiver) = mpsc::channel(1);
+        let artifact_service = ArtifactService::new(&tmp_dir, build_command_sender, p2p_client)
             .expect("Creating ArtifactService failed");
 
         let filter = make_docker_routes(Arc::new(Mutex::new(artifact_service)));
@@ -96,14 +95,14 @@ mod tests {
     async fn docker_routes_blobs() {
         let tmp_dir = test_util::tests::setup();
 
-        let (sender, _) = mpsc::channel(1);
+        let (command_sender, _command_receiver) = mpsc::channel(1);
         let p2p_client = Client {
-            sender,
+            sender: command_sender,
             local_peer_id: Keypair::generate_ed25519().public().to_peer_id(),
         };
 
-        let build_service = BuildService::new(&tmp_dir, "", "").unwrap();
-        let artifact_service = ArtifactService::new(&tmp_dir, p2p_client, build_service)
+        let (build_command_sender, _build_command_receiver) = mpsc::channel(1);
+        let artifact_service = ArtifactService::new(&tmp_dir, build_command_sender, p2p_client)
             .expect("Creating ArtifactService failed");
 
         let filter = make_docker_routes(Arc::new(Mutex::new(artifact_service)));
@@ -127,14 +126,14 @@ mod tests {
     async fn docker_routes_manifests() {
         let tmp_dir = test_util::tests::setup();
 
-        let (sender, _) = mpsc::channel(1);
+        let (command_sender, _command_receiver) = mpsc::channel(1);
         let p2p_client = Client {
-            sender,
+            sender: command_sender,
             local_peer_id: Keypair::generate_ed25519().public().to_peer_id(),
         };
 
-        let build_service = BuildService::new(&tmp_dir, "", "").unwrap();
-        let artifact_service = ArtifactService::new(&tmp_dir, p2p_client, build_service)
+        let (build_command_sender, _build_command_receiver) = mpsc::channel(1);
+        let artifact_service = ArtifactService::new(&tmp_dir, build_command_sender, p2p_client)
             .expect("Creating ArtifactService failed");
 
         let filter = make_docker_routes(Arc::new(Mutex::new(artifact_service)));

--- a/src/java/maven2/handlers/maven_artifacts.rs
+++ b/src/java/maven2/handlers/maven_artifacts.rs
@@ -87,7 +87,6 @@ fn get_package_specific_artifact_id(full_path: &str) -> Result<String, anyhow::E
 mod tests {
     use super::*;
     use crate::artifact_service::storage::ArtifactStorage;
-    use crate::build_service::service::BuildService;
     use crate::network::client::Client;
     use crate::transparency_log::log::AddArtifactRequest;
     use crate::util::test_util;
@@ -100,8 +99,6 @@ mod tests {
 
     const VALID_ARTIFACT_HASH: &str =
         "e11c16ff163ccc1efe01d2696c626891560fa82123601a5ff196d97b6ab156da";
-    const VALID_SOURCE_HASH: &str =
-        "b6f87982af625a228822adf42d0a091d40e96220b6d4d09a566173b9ea072e34";
     const VALID_FULL_PATH: &str = "/maven2/test/test/1.0/test-1.0.jar";
     const INVALID_FULL_PATH: &str = "/maven2/test/1.0/test-1.0.jar";
     const VALID_MAVEN_ID: &str = "test:test:1.0";
@@ -131,8 +128,8 @@ mod tests {
             local_peer_id: Keypair::generate_ed25519().public().to_peer_id(),
         };
 
-        let build_service = BuildService::new(&tmp_dir, "", "").unwrap();
-        let mut artifact_service = ArtifactService::new(&tmp_dir, p2p_client, build_service)
+        let (build_command_sender, _build_command_receiver) = mpsc::channel(1);
+        let mut artifact_service = ArtifactService::new(&tmp_dir, build_command_sender, p2p_client)
             .expect("Creating ArtifactService failed");
 
         artifact_service
@@ -143,7 +140,6 @@ mod tests {
                     package_specific_id: VALID_MAVEN_ID.to_owned(),
                     package_specific_artifact_id: VALID_MAVEN_ARTIFACT_ID.to_owned(),
                     artifact_hash: VALID_ARTIFACT_HASH.to_owned(),
-                    source_hash: VALID_SOURCE_HASH.to_owned(),
                 },
                 add_artifact_sender,
             )

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -116,13 +116,13 @@ impl Client {
 
     /// Inform the swarm that this node is currently a provider
     /// of the artifact with the specified `artifact_id`.
-    pub async fn provide(&mut self, artifact_id: String) -> anyhow::Result<()> {
+    pub async fn provide(&mut self, artifact_id: &str) -> anyhow::Result<()> {
         debug!("p2p::Client::provide {:?}", artifact_id);
 
         let (sender, receiver) = oneshot::channel();
         self.sender
             .send(Command::Provide {
-                artifact_id,
+                artifact_id: artifact_id.to_owned(),
                 sender,
             })
             .await?;
@@ -380,7 +380,7 @@ mod tests {
             .map(char::from)
             .collect();
         let cloned_random_artifact_id = random_artifact_id.clone();
-        tokio::spawn(async move { client.provide(random_artifact_id).await });
+        tokio::spawn(async move { client.provide(&random_artifact_id).await });
 
         tokio::select! {
             command = receiver.recv() => match command {

--- a/src/transparency_log/log.rs
+++ b/src/transparency_log/log.rs
@@ -90,12 +90,12 @@ pub struct TransparencyLog {
     node_public_key: String,
 }
 
+#[derive(Debug)]
 pub struct AddArtifactRequest {
     pub package_type: PackageType,
     pub package_specific_id: String,
     pub package_specific_artifact_id: String,
     pub artifact_hash: String,
-    pub source_hash: String,
 }
 
 pub struct AuthorizedNode {
@@ -146,7 +146,7 @@ impl TransparencyLogService {
             package_specific_id: add_artifact_request.package_specific_id.clone(),
             package_specific_artifact_id: add_artifact_request.package_specific_artifact_id.clone(),
             artifact_hash: add_artifact_request.artifact_hash,
-            source_hash: add_artifact_request.source_hash,
+            source_hash: "".to_owned(),
             artifact_id: Uuid::new_v4().to_string(),
             source_id: Uuid::new_v4().to_string(),
             timestamp: SystemTime::now()
@@ -684,7 +684,6 @@ mod tests {
                     package_specific_id: "package_specific_id".to_owned(),
                     package_specific_artifact_id: "package_specific_artifact_id".to_owned(),
                     artifact_hash: "artifact_hash".to_owned(),
-                    source_hash: "source_hash".to_owned(),
                 },
                 sender,
             )


### PR DESCRIPTION
## Description

Fixes pyrsia/pyrsia#794

This PR implements the final step in the build from source flow. It integrates all the involved services to get an end-to-end working prototype for building artifacts from source.

- introduce a build event loop to listen for build completion events
- the CLI hooks directly invoke `build_service.start_build()` instead of going through the `artifact_service`
- the build service starts the build on the remote build pipeline and waits for it to complete
- upon completion:
  - the build service handles the completed build by mapping each artifact to a PSAID and downloading them to a temporary folder
  - a build successful event is sent to the build event loop
- the build event loop calls `artifact_service.handle_build_result()` for a build successful event
- the artifact service handles the build result by:
  - adding the artifact to the transparency log
  - putting the artifact in the local artifact storage
  - start providing the artifact on the p2p network

## PR Checklist

<!-- Make certain you've done the following. -->

- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/get_involved/good_pr.md)
- [x] I've included a good title and brief description along with how to review them.
- [x] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).

### Code Contributions

<!--

This section applies to code modifications, you may remove it otherwise.

Make sure your Pull Request will pass the CI/CD pipeline.
For a complete list of steps, check out the [developer workflow](https://github.com/pyrsia/pyrsia/blob/main/docs/get_involved/dev_workflow.md)!

-->

- [x] I've built the code `cargo build --all-targets` successfully.
- [x] I've run the unit tests `cargo test --workspace` and everything passes.
- [x] I've made sure my rust toolchain is current `rustup update`.
