### PR TITLE
Fixes the Project board automation to use the one that works with beta version of the board

### DIFF
--- a/.github/workflows/board-automation.yml
+++ b/.github/workflows/board-automation.yml
@@ -5,9 +5,16 @@ on:
     types: [opened, reopened, labeled]
   pull_request_target:
     types: [opened, closed, reopened, labeled, ready_for_review, review_requested]
+env:
+  todo: Todo
+  done: Done
+  in_progress: In Progress
+  mvp: MVP
+  blocked: Blocked
 
 jobs:
   new-issues:
+    name: new-issues
     runs-on: ubuntu-latest
     if: |
       github.repository_owner == 'pyrsia' &&
@@ -17,25 +24,33 @@ jobs:
       - uses: actions-ecosystem/action-add-labels@v1
         with:
           labels: triage
-      - uses: alex-page/github-project-automation-plus@v0.8.1
+      - name: Moved issue to ${{ env.mvp }}
+        uses: leonsteinhaeuser/project-beta-automations@v1.2.1
         with:
           project: Pyrsia Development
           action: add
-          column: MVP
-          repo-token: ${{ secrets.ORG_ACCESS_TOKEN }}
+          status_value: ${{ env.mvp }}
+          project_id: 3
+          organization: pyrsia
+          gh_token: ${{ secrets.ORG_ACCESS_TOKEN }}
+          resource_node_id: ${{ github.event.issue.node_id }}
 
   new-prs:
+    name: new-prs
     runs-on: ubuntu-latest
     if: |
       github.repository_owner == 'pyrsia' &&
-      github.event_name == 'pull_request_target' &&
+      github.event_name == 'pull_request' &&
       (github.event.action == 'opened' || github.event.action == 'reopened')
     steps:
-      - uses: alex-page/github-project-automation-plus@v0.8.1
+      - uses: leonsteinhaeuser/project-beta-automations@v1.2.1
         with:
           project: Pyrsia Development
           column: In Progress
-          repo-token: ${{ secrets.ORG_ACCESS_TOKEN }}
+          project_id: 3
+          organization: pyrsia
+          gh_token: ${{ secrets.ORG_ACCESS_TOKEN }}
+          resource_node_id: ${{ github.event.issue.node_id }}
 
   pr-request-review:
     runs-on: ubuntu-latest
@@ -55,11 +70,13 @@ jobs:
       (github.event_name == 'issues' ||  github.event_name == 'pull_request_target') &&
       github.event.action == 'labeled' && github.event.label.name == 'blocked'
     steps:
-      - uses: alex-page/github-project-automation-plus@v0.8.1
+      - uses: leonsteinhaeuser/project-beta-automations@v1.2.1
         with:
-          project: Pyrsia Development
-          column: Blocked
-          repo-token: ${{ secrets.ORG_ACCESS_TOKEN }}
+          column: ${{ env.blocked }}
+          project_id: 3
+          organization: pyrsia
+          gh_token: ${{ secrets.ORG_ACCESS_TOKEN }}
+          resource_node_id: ${{ github.event.issue.node_id }}
 
   assign-author:
     runs-on: ubuntu-latest
@@ -76,9 +93,11 @@ jobs:
       github.repository_owner == 'pyrsia' &&
       github.event_name == 'pull_request_target' && github.event.action == 'closed'
     steps:
-      - uses: alex-page/github-project-automation-plus@v0.8.1
+      - uses: leonsteinhaeuser/project-beta-automations@v1.2.1
         with:
           project: Pyrsia Development
-          action: delete
-          column: To do
-          repo-token: ${{ secrets.ORG_ACCESS_TOKEN }}
+          column: ${{ env.done }}
+          project_id: 3
+          organization: pyrsia
+          gh_token: ${{ secrets.ORG_ACCESS_TOKEN }}
+          resource_node_id: ${{ github.event.issue.node_id }}


### PR DESCRIPTION
Fixes the project board automation to use a marketplace version that works with Github beta project boards

This PR does Fixes the project board automation to use a marketplace version that works with Github beta project boards
We have migrated to using the beta version of project boards since it has better features that we can leverage. On doing so our old workflows for project board do not work. Hence we need to use a new version from the marketplace. This PR applies those changes and modifies the automation to adapt to new variables and code.
(The https://github.com/pyrsia/pyrsia/runs/7546541571?check_suite_focus=true PR that is waiting on this fix)

## PR Checklist

<!-- Make certain you've done the following. -->

- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/get_involved/good_pr.md)
- [x] I've included a good title and brief description along with how to review them.
- [x] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).

This is a code contribution but can only be tested on github when we use project board.