### PR TITLE
configure sample maven project with valid release

### DIFF
--- a/docs/tutorials/build_from_source.md
+++ b/docs/tutorials/build_from_source.md
@@ -349,6 +349,19 @@ Create a `pom.xml` file:
             <version>1.15</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
+                <configuration>
+                    <release>11</release>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>
 ```
 


### PR DESCRIPTION
## Description

Fixes pyrsia/pyrsia#908

This PR fixes configuration of the sample maven project by setting the `-release` to 11.

## PR Checklist

- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/get_involved/good_pr.md)
- [x] I've included a good title and brief description along with how to review them.
- [x] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).