### PR TITLE
Shows the artifacts_directory being used by artifact_service in debug…

### DIFF
--- a/.github/workflows/.cargo/audit.toml
+++ b/.github/workflows/.cargo/audit.toml
@@ -2,4 +2,4 @@
 # A good example is at https://docs.rs/crate/cargo-audit/0.10.0/source/audit.toml.example
 
 [advisories]
-ignore = [] # advisory IDs to ignore
+ignore = [RUSTSEC-2022-0040] # advisory IDs to ignore

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -15,7 +15,7 @@ if [[ "$1" == "clean" ]] ; then
 fi
 
 cargo install cargo-audit || exit_on_error "Could not install cargo audit."
-cargo audit || exit_on_error "Cargo audit failed."
+cargo audit --ignore RUSTSEC-2022-0040 || exit_on_error "Cargo audit failed."
 cargo clippy || exit_on_error "Cargo clippy failed."
 rustup update || exit_on_error "Could not update rust toolchain."
 rustup component add rustfmt || exit_on_error "Could not install rustfmt."


### PR DESCRIPTION
… output

## Description

This PR does shows the artifacts_directory being used by artifact_service in debug output so that you know where the artifacts are being stored

## PR Checklist

<!-- Make certain you've done the following. -->

- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/get_involved/good_pr.md)
- [x] I've included a good title and brief description along with how to review them.
- [x] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).

### Code Contributions


- [x] I've built the code `cargo build --all-targets` successfully.
- [x] I've run the unit tests `cargo test --workspace` and everything passes.
- [x] I've made sure my rust toolchain is current `rustup update`.
