### PR TITLE
Ignores the advisory for owning_ref

### DIFF
--- a/.github/workflows/.cargo/audit.toml
+++ b/.github/workflows/.cargo/audit.toml
@@ -2,4 +2,4 @@
 # A good example is at https://docs.rs/crate/cargo-audit/0.10.0/source/audit.toml.example
 
 [advisories]
-ignore = [] # advisory IDs to ignore
+ignore = [RUSTSEC-2022-0040] # advisory IDs to ignore

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -15,7 +15,7 @@ if [[ "$1" == "clean" ]] ; then
 fi
 
 cargo install cargo-audit || exit_on_error "Could not install cargo audit."
-cargo audit || exit_on_error "Cargo audit failed."
+cargo audit --ignore RUSTSEC-2022-0040 || exit_on_error "Cargo audit failed."
 cargo clippy || exit_on_error "Cargo clippy failed."
 rustup update || exit_on_error "Could not update rust toolchain."
 rustup component add rustfmt || exit_on_error "Could not install rustfmt."


### PR DESCRIPTION
- owning_ref is a dependency of libp2p and has a vulnerability that does not have an upgrade path
- this breaks our audit check and hence we need to ignore it till the upgrade is available.
- this vulnerability has been around since Jan 2022 and also the codebase has not been updated for 2 years
- so our mileage is going to be meh.
- https://github.com/libp2p/rust-libp2p/issues/2794

## Description

Ignores vulnerability that is causing audit to fail on github actions due to issues with owning_ref

This PR does..

Ignores the advisory for owning_ref
- owning_ref is a dependency of libp2p and has a vulnerability that does not have an upgrade path
- this breaks our audit check and hence we need to ignore it till the upgrade is available.
- this vulnerability has been around since Jan 2022 and also the codebase has not been updated for 2 years
- so our mileage is going to be meh.
- https://github.com/libp2p/rust-libp2p/issues/2794

## PR Checklist

- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/get_involved/good_pr.md)
- [x] I've included a good title and brief description along with how to review them.
- [x] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).

### Code Contributions

- [x] I've built the code `cargo build --all-targets` successfully.
- [x] I've run the unit tests `cargo test --workspace` and everything passes.
- [x] I've made sure my rust toolchain is current `rustup update`.
- Although I have run the precommit script that runs all the above the github action change will only be testable on github