### PR TITLE
pyrsia ping - Confusing message when node is running on non default p…

### DIFF
--- a/pyrsia_cli/src/cli/handlers.rs
+++ b/pyrsia_cli/src/cli/handlers.rs
@@ -21,6 +21,8 @@ use std::collections::HashSet;
 use std::io;
 use std::io::BufRead;
 
+const CONF_REMINDER_MESSAGE: &str = "Please make sure the pyrsia CLI config is up to date and matches the node configuration. For more information, run 'pyrsia config --show'";
+
 pub fn config_add() {
     println!("Enter host: ");
     let mut new_cfg = config::CliConfig {
@@ -94,7 +96,7 @@ pub async fn node_ping() {
             println!("Connection Successful !!")
         }
         Err(error) => {
-            println!("Error: {}", error);
+            println!("Error: {}. {}", error, CONF_REMINDER_MESSAGE);
         }
     };
 }
@@ -106,7 +108,7 @@ pub async fn node_status() {
             println!("Connected Peers Count:       {}", resp.peers_count);
         }
         Err(error) => {
-            println!("Error: {}", error);
+            println!("Error: {}. {}", error, CONF_REMINDER_MESSAGE);
         }
     }
 }
@@ -124,7 +126,7 @@ pub async fn node_list() {
             unique_peers.iter().for_each(|p| println!("{}", p));
         }
         Err(error) => {
-            println!("Error: {}", error);
+            println!("Error: {}. {}", error, CONF_REMINDER_MESSAGE);
         }
     }
 }


### PR DESCRIPTION
…ort (7888) and the config is not updated

<!--

Thank you for participating with our effort to build a more secure software supply chain.
Before submitting your Pull Request, please go over our check list.

-->

## Description

Trivial fix/message adjustment - pyrsia ping - Confusing message when node is running on non default port (7888) and the pyrsia CLI config is not updated. It should help to remind users that the "pyrsia CLI" config might be out of sync with the node config when the connection error happens.

 
<!--

Try to fill in the following to help the reviewers dive into the pull request.
Explain the context and what changed.

-->

Fixes pyrsia/pyrsia#

More descriptive error message.

## Screenshots (optional)

## PR Checklist

<!-- Make certain you've done the following. -->

- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/get_involved/good_pr.md)
- [x] I've included a good title and brief description along with how to review them.
- [x] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).

### Code Contributions

<!--

This section applies to code modifications, you may remove it otherwise.

Make sure your Pull Request will pass the CI/CD pipeline.
For a complete list of steps, check out the [developer workflow](https://github.com/pyrsia/pyrsia/blob/main/docs/get_involved/dev_workflow.md)!

-->

- [x] I've built the code `cargo build --all-targets` successfully.
- [x] I've run the unit tests `cargo test --workspace` and everything passes.
- [x] I've made sure my rust toolchain is current `rustup update`.
