### PR TITLE
Adds an onboarding page to describe onboarding process

### DIFF
--- a/docs/community/get_involved/good_pr.md
+++ b/docs/community/get_involved/good_pr.md
@@ -10,7 +10,7 @@ With that in mind, what should authors do to make this process as smooth as poss
 ## What makes a good Pull Request
 
 * Link to an issue that has clear description so reviewers know what to expect.
-* Keep the changes small, limit the scope of the PR to make it clear an concise.
+* Keep the changes small, limit the scope of the PR to make it clear and concise.
 * Fill in the PR template to give the most information as possible.
   * Clear title
   * Detailed description
@@ -27,11 +27,11 @@ With that in mind, what should authors do to make this process as smooth as poss
 ### Possible solutions
 
 * Open new issues for the extra work you spot in the code if it takes more then 30 minutes.
-  * Focus on the issue at hand!
-  * Clearly call out changes in the description of code comments to inform the reviewer.
-* Document design decision in the `docs/` folder of write a blog for the website.
-  * Share the link to a Google Docs describing the decision and choices made.
-  * Include any meeting records where the issue was discussed
+* Focus on the issue at hand!
+* Clearly call out changes in the description of code comments to inform the reviewer.
+* Document design decision in the `docs/` folder.
+* Share the link to a Google Docs describing the decision and choices made.
+* Include any meeting records where the issue was discussed
 
 ## Test cases
 

--- a/docs/community/get_involved/onboarding.md
+++ b/docs/community/get_involved/onboarding.md
@@ -1,0 +1,26 @@
+# New to Pyrsia
+
+If you are new to the Pyrsia team here are a few steps to get you started.
+
+1. Find the [googlegroup for Pyrsia](https://groups.google.com/g/pyrsia) and request membership
+2. Your membership will allow you to look at the Pyrsia Googlegroup calendar and you will be able to receive invites for all the team meetings
+3. Find the [slack channel for Pyrsia](https://join.slack.com/t/openssf/shared_invite/zt-1cx4yg0jn-JApp_AO~JV7fO0k6LrcuGA) and join
+4. On Slack, introduce yourself and give us some background - what brought you to Pyrsia and how you would like to get involved.
+5. While the googlegroup membership is being approved - which should take less than a day usually - watch some videos about [Pyrsia on Youtube](https://www.youtube.com/channel/UClPQKloIElvJk7EdSST3W5g) to make yourself familiar with the team and progress so far
+6. You do not need any membership to look at the code and send us a PR or create an issue.
+   1. [Code is on Github](https://github.com/pyrsia)
+   2. We use [Github project](https://github.com/orgs/pyrsia/projects/3) to manage our tasks
+7. Pyrsia team uses a shared Google doc folder for collaborating outside of the codebase - Request to share that folder on Slack
+8. Pyrsia team uses LucidChart for drawings and doodles that help with better communication - Request access to the LucidCharts on Slack
+9. Pyrsia team follows a 2 week sprint model and has Sprint planning once every two weeks
+10. Pyrsia team has a retrospective at the end of every Sprint to reflect on the feedback.
+
+Once you have received the requisite permissions, please join one of the team standups or start asking questions on the Slack channel. If you are looking to share a new design or have a proposal head over to our [RFC process](https://pyrsia.io/docs/community/rfc/) to submit it.
+
+Once you are all set you can follow the instructions to [setup your development environment](./local_dev_setup.md/).
+
+Once you are ready to submit a PR [learn about contributing to Pyrsia](./contributing.md) and start [submitting PRs](https://pyrsia.io/docs/community/get_involved/submit_pr/).
+
+If you are looking to contribute documentation we have some [documentation contribution guidelines](./doc_workflow.md) to make things easier for you.
+
+Welcome to the team!

--- a/docs/community/get_involved/submit_pr.md
+++ b/docs/community/get_involved/submit_pr.md
@@ -1,5 +1,7 @@
 # Submit a PR
 
+If you haven't already, read about what we consider as [Good PRs](./good_pr.md).
+
 When developing new features for Pyrsia, we aim for the best quality code possible. Here's the steps with some "How To"s on getting there.
 
 We also have "pre commit" scripts (located in the root of the repository) which will run on of these steps.

--- a/docs/tutorials/setting_up_ide.md
+++ b/docs/tutorials/setting_up_ide.md
@@ -4,7 +4,7 @@ This tutorial describes how to start and debug Pyrsia using Microsoft Visual Cod
 
 ## Prerequisites
 
-Before continuing please make sure that you have cloned and compiled the Pyrsia sources. For more information please see [Getting Started](../get_involved/local_dev_setup.md). In this tutorial `PYRSIA_HOME` refers to the Pyrsia repository folder.
+Before continuing please make sure that you have cloned and compiled the Pyrsia sources. For more information please see [Developer Environment Setup](../get_involved/local_dev_setup.md). In this tutorial `PYRSIA_HOME` refers to the Pyrsia repository folder.
 
 ## IntelliJ IDEA Configuration
 

--- a/pyrsia_cli/readme.md
+++ b/pyrsia_cli/readme.md
@@ -4,7 +4,7 @@ Parses command lines and subcommands, then communicates the parsed requests to a
 
 ## Building
 
-1. Follow our [Getting Started](https://pyrsia.io/docs/developer/local_dev_setup/) section
+1. Follow our [Developer Environment Setup](https://pyrsia.io/docs/developer/local_dev_setup/) section
 2. Run the build release command for package `pyrsia_cli` which generates an executable in `./target/release/pyrsia`
 
 ```sh

--- a/src/blockchain/readme.md
+++ b/src/blockchain/readme.md
@@ -7,11 +7,9 @@ This will encompass:
 - recording new "transaction" accepting generic payload
 - returning finalized blocks
 
-## Getting started
+This can be built from the project root since it's a part of the workspace.
 
-This can be built from the project root since it's apart of the workspace.
-
-### Running the example Node
+## Running the example Node
 
 ```sh
 cargo build --examples


### PR DESCRIPTION
## Description

This PR does adds onboarding documentation
Adds an onboarding page to describe onboarding process
    - helps with not repeating the same message for new joinees
    - removed 'Getting Started' and replaced with setting up dev env because that is what the document described
    - adds details that were only known to select members so that onboarding does not get blocked due to truck factor.

## PR Checklist

- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/get_involved/good_pr.md)
- [x] I've included a good title and brief description along with how to review them.
- [x] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).

