### PR TITLE
Fixes the automation that depended on resource_node_id

### DIFF
--- a/.github/workflows/board-automation.yml
+++ b/.github/workflows/board-automation.yml
@@ -48,7 +48,7 @@ jobs:
           project_id: 3
           organization: pyrsia
           gh_token: ${{ secrets.ORG_ACCESS_TOKEN }}
-          resource_node_id: ${{ github.event.issue.node_id }}
+          resource_node_id: ${{ github.event.pull_request.node_id }}
 
   pr-request-review:
     runs-on: ubuntu-latest
@@ -97,4 +97,4 @@ jobs:
           project_id: 3
           organization: pyrsia
           gh_token: ${{ secrets.ORG_ACCESS_TOKEN }}
-          resource_node_id: ${{ github.event.issue.node_id }}
+          resource_node_id: ${{ github.event.pull_request.node_id }}


### PR DESCRIPTION
- for PRs we need to get the node_id from the pull_request instead of the github issue


## Description

Fixes failures like these https://github.com/pyrsia/pyrsia/runs/7782157840?check_suite_focus=true

This PR fixes the automation that depended on resource_node_id

## Screenshots (optional)

## PR Checklist

<!-- Make certain you've done the following. -->

- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/get_involved/good_pr.md)
- [x] I've included a good title and brief description along with how to review them.
- [x] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).

### Code Contributions
This is a code contribution but related to project board and does not change any application code. Hence the following section is skipped.
