### PR TITLE
Minimize usage of mutexes

### DIFF
--- a/pyrsia_node/src/main.rs
+++ b/pyrsia_node/src/main.rs
@@ -32,9 +32,9 @@ use pyrsia::logging::*;
 use pyrsia::network::client::Client;
 use pyrsia::network::p2p;
 use pyrsia::node_api::routes::make_node_routes;
+use pyrsia::transparency_log::log::TransparencyLogService;
 use pyrsia::util::keypair_util::{self, KEYPAIR_FILENAME};
 use pyrsia::verification_service::service::VerificationService;
-use pyrsia_blockchain_network::blockchain::Blockchain;
 
 use clap::Parser;
 use log::{debug, info, warn};
@@ -62,12 +62,21 @@ async fn main() -> Result<(), Box<dyn Error>> {
     debug!("Create blockchain service component");
     let blockchain_service = setup_blockchain_service(p2p_client.clone())?;
 
+    debug!("Create transparency log service");
+    let transparency_log_service = setup_transparency_log_service(blockchain_service.clone())?;
+
     debug!("Create pyrsia services");
-    let artifact_service =
-        setup_pyrsia_services(blockchain_service, p2p_client.clone(), &args).await?;
+    let (build_event_client, artifact_service) =
+        setup_pyrsia_services(transparency_log_service.clone(), p2p_client.clone(), &args).await?;
 
     debug!("Setup HTTP server");
-    setup_http(&args, artifact_service.clone());
+    setup_http(
+        &args,
+        artifact_service.clone(),
+        transparency_log_service,
+        build_event_client,
+        p2p_client.clone(),
+    );
 
     debug!("Start p2p components");
     setup_p2p(p2p_client.clone(), &args).await?;
@@ -110,6 +119,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 } => {
                     if let Err(error) = handlers::handle_request_block_update(
                         artifact_service.clone(),
+                        blockchain_service.clone(),
                         block_ordinal,
                         block.clone(),
                     )
@@ -186,7 +196,7 @@ async fn load_peer_addrs(peer_url: &str) -> anyhow::Result<String> {
     }
 }
 
-fn setup_blockchain_service(p2p_client: Client) -> Result<BlockchainService> {
+fn setup_blockchain_service(p2p_client: Client) -> Result<Arc<Mutex<BlockchainService>>> {
     let local_keypair =
         keypair_util::load_or_generate_ed25519(PathBuf::from(KEYPAIR_FILENAME.as_str()));
 
@@ -197,25 +207,37 @@ fn setup_blockchain_service(p2p_client: Client) -> Result<BlockchainService> {
         }
     };
 
-    Ok(BlockchainService {
-        blockchain: Blockchain::new(&ed25519_keypair),
+    Ok(Arc::new(Mutex::new(BlockchainService::new(
+        &ed25519_keypair,
         p2p_client,
-    })
+    ))))
+}
+
+fn setup_transparency_log_service(
+    blockchain_service: Arc<Mutex<BlockchainService>>,
+) -> Result<TransparencyLogService> {
+    let artifact_path = PathBuf::from(ARTIFACTS_DIR.as_str());
+
+    let transparency_log_service = TransparencyLogService::new(&artifact_path, blockchain_service)?;
+
+    Ok(transparency_log_service)
 }
 
 async fn setup_pyrsia_services(
-    blockchain_service: BlockchainService,
+    transparency_log_service: TransparencyLogService,
     p2p_client: Client,
     args: &PyrsiaNodeArgs,
-) -> Result<Arc<Mutex<ArtifactService>>> {
+) -> Result<(BuildEventClient, ArtifactService)> {
     let artifact_path = PathBuf::from(ARTIFACTS_DIR.as_str());
+
+    debug!("Create build event client");
     let (build_event_sender, build_event_receiver) = mpsc::channel(32);
     let build_event_client = BuildEventClient::new(build_event_sender);
 
     debug!("Create artifact service");
     let artifact_service = setup_artifact_service(
         &artifact_path,
-        blockchain_service,
+        transparency_log_service,
         build_event_client.clone(),
         p2p_client,
     )?;
@@ -224,7 +246,7 @@ async fn setup_pyrsia_services(
     let build_service = setup_build_service(&artifact_path, build_event_client.clone(), args)?;
 
     debug!("Create verification service");
-    let verification_service = setup_verification_service(build_event_client)?;
+    let verification_service = VerificationService::new(build_event_client.clone())?;
 
     debug!("Start build event loop");
     let build_event_loop = BuildEventLoop::new(
@@ -235,34 +257,30 @@ async fn setup_pyrsia_services(
     );
     tokio::spawn(build_event_loop.run());
 
-    Ok(artifact_service)
+    Ok((build_event_client, artifact_service))
 }
 
 fn setup_artifact_service(
     artifact_path: &Path,
-    blockchain_service: BlockchainService,
+    transparency_log_service: TransparencyLogService,
     build_event_client: BuildEventClient,
     p2p_client: Client,
-) -> Result<Arc<Mutex<ArtifactService>>> {
-    let local_keypair =
-        keypair_util::load_or_generate_ed25519(PathBuf::from(KEYPAIR_FILENAME.as_str()));
-
+) -> Result<ArtifactService> {
     let artifact_service = ArtifactService::new(
         artifact_path,
-        local_keypair,
-        blockchain_service,
+        transparency_log_service,
         build_event_client,
         p2p_client,
     )?;
 
-    Ok(Arc::new(Mutex::new(artifact_service)))
+    Ok(artifact_service)
 }
 
 fn setup_build_service(
     artifact_path: &Path,
     build_event_client: BuildEventClient,
     args: &PyrsiaNodeArgs,
-) -> Result<Arc<Mutex<BuildService>>> {
+) -> Result<BuildService> {
     let build_service = BuildService::new(
         &artifact_path,
         build_event_client,
@@ -270,18 +288,16 @@ fn setup_build_service(
         &args.pipeline_service_endpoint,
     )?;
 
-    Ok(Arc::new(Mutex::new(build_service)))
+    Ok(build_service)
 }
 
-fn setup_verification_service(
+fn setup_http(
+    args: &PyrsiaNodeArgs,
+    artifact_service: ArtifactService,
+    transparency_log_service: TransparencyLogService,
     build_event_client: BuildEventClient,
-) -> Result<Arc<Mutex<VerificationService>>> {
-    let verification_service = VerificationService::new(build_event_client)?;
-
-    Ok(Arc::new(Mutex::new(verification_service)))
-}
-
-fn setup_http(args: &PyrsiaNodeArgs, artifact_service: Arc<Mutex<ArtifactService>>) {
+    p2p_client: Client,
+) {
     // Get host and port from the settings. Defaults to DEFAULT_HOST and DEFAULT_PORT
     debug!(
         "Pyrsia Docker Node will bind to host = {}, port = {}",
@@ -295,8 +311,9 @@ fn setup_http(args: &PyrsiaNodeArgs, artifact_service: Arc<Mutex<ArtifactService
 
     debug!("Setup HTTP routing");
     let docker_routes = make_docker_routes(artifact_service.clone());
-    let maven_routes = make_maven_routes(artifact_service.clone());
-    let node_api_routes = make_node_routes(artifact_service);
+    let maven_routes = make_maven_routes(artifact_service);
+    let node_api_routes =
+        make_node_routes(build_event_client, p2p_client, transparency_log_service);
     let all_routes = docker_routes.or(maven_routes).or(node_api_routes);
 
     debug!("Setup HTTP server");

--- a/src/artifact_service/service.rs
+++ b/src/artifact_service/service.rs
@@ -16,7 +16,6 @@
 
 use super::model::PackageType;
 use super::storage::ArtifactStorage;
-use crate::blockchain_service::service::BlockchainService;
 use crate::build_service::error::BuildError;
 use crate::build_service::event::BuildEventClient;
 use crate::build_service::model::BuildResult;
@@ -25,7 +24,6 @@ use crate::transparency_log::log::{
     AddArtifactRequest, TransparencyLog, TransparencyLogError, TransparencyLogService,
 };
 use anyhow::{bail, Context};
-use libp2p::identity::Keypair;
 use libp2p::PeerId;
 use log::info;
 use multihash::Hasher;
@@ -37,11 +35,10 @@ use std::str;
 /// The artifact service is the component that handles everything related to
 /// pyrsia artifacts. It allows artifacts to be retrieved and added to the
 /// pyrsia network by requesting a build from source.
+#[derive(Clone)]
 pub struct ArtifactService {
     pub artifact_storage: ArtifactStorage,
     build_event_client: BuildEventClient,
-    local_keypair: Keypair,
-    pub blockchain_service: BlockchainService,
     pub transparency_log_service: TransparencyLogService,
     pub p2p_client: Client,
 }
@@ -49,18 +46,14 @@ pub struct ArtifactService {
 impl ArtifactService {
     pub fn new<P: AsRef<Path>>(
         artifact_path: P,
-        local_keypair: Keypair,
-        blockchain_service: BlockchainService,
+        transparency_log_service: TransparencyLogService,
         build_event_client: BuildEventClient,
         p2p_client: Client,
     ) -> anyhow::Result<Self> {
         let artifact_storage = ArtifactStorage::new(&artifact_path)?;
-        let transparency_log_service = TransparencyLogService::new(artifact_path)?;
         Ok(ArtifactService {
             artifact_storage,
             build_event_client,
-            local_keypair,
-            blockchain_service,
             transparency_log_service,
             p2p_client,
         })
@@ -104,17 +97,12 @@ impl ArtifactService {
 
             let add_artifact_transparency_log = self
                 .transparency_log_service
-                .create_add_artifact(add_artifact_request)
+                .add_artifact(add_artifact_request)
                 .await?;
             info!(
                 "Transparency Log for build with ID {} successfully created.",
                 build_id
             );
-
-            let payload = serde_json::to_string(&add_artifact_transparency_log).unwrap();
-            self.blockchain_service
-                .add_payload(payload.into_bytes(), &self.local_keypair)
-                .await;
 
             self.transparency_log_service
                 .write_transparency_log(&add_artifact_transparency_log)?;
@@ -275,15 +263,19 @@ impl ArtifactService {
 #[cfg(not(tarpaulin_include))]
 mod tests {
     use super::*;
+    use crate::blockchain_service::service::BlockchainService;
     use crate::build_service::event::BuildEvent;
     use crate::network::client::command::Command;
     use crate::network::idle_metric_protocol::PeerMetrics;
     use crate::util::test_util;
+    use libp2p::identity::ed25519::Keypair;
+    use libp2p::identity::PublicKey;
     use sha2::{Digest, Sha256};
     use std::collections::HashSet;
     use std::env;
     use std::path::PathBuf;
-    use tokio::sync::mpsc;
+    use std::sync::Arc;
+    use tokio::sync::{mpsc, Mutex};
     use tokio::task;
 
     const VALID_ARTIFACT_HASH: [u8; 32] = [
@@ -292,11 +284,11 @@ mod tests {
         0x4f,
     ];
 
-    fn create_p2p_client() -> (mpsc::Receiver<Command>, Client) {
+    fn create_p2p_client(keypair: &Keypair) -> (mpsc::Receiver<Command>, Client) {
         let (command_sender, command_receiver) = mpsc::channel(1);
         let p2p_client = Client {
             sender: command_sender,
-            local_peer_id: Keypair::generate_ed25519().public().to_peer_id(),
+            local_peer_id: PublicKey::Ed25519(keypair.public()).to_peer_id(),
         };
 
         (command_receiver, p2p_client)
@@ -304,25 +296,24 @@ mod tests {
 
     fn create_artifact_service<P: AsRef<Path>>(
         artifact_path: P,
+        keypair: &Keypair,
         p2p_client: Client,
     ) -> (mpsc::Receiver<BuildEvent>, ArtifactService) {
-        let local_keypair = Keypair::generate_ed25519();
-        let ed25519_keypair = match local_keypair {
-            libp2p::identity::Keypair::Ed25519(ref v) => v,
-            _ => {
-                panic!("Keypair Format Error");
-            }
-        };
+        let blockchain_service = Arc::new(Mutex::new(BlockchainService::new(
+            keypair,
+            p2p_client.clone(),
+        )));
 
-        let blockchain_service = BlockchainService::new(ed25519_keypair, p2p_client.clone());
+        let transparency_log_service =
+            TransparencyLogService::new(&artifact_path, blockchain_service)
+                .expect("Creating TransparencyLogService failed");
 
         let (build_event_sender, build_event_receiver) = mpsc::channel(1);
         let build_event_client = BuildEventClient::new(build_event_sender);
 
         let artifact_service = ArtifactService::new(
             &artifact_path,
-            local_keypair,
-            blockchain_service,
+            transparency_log_service,
             build_event_client,
             p2p_client,
         )
@@ -335,9 +326,11 @@ mod tests {
     async fn test_put_and_get_artifact() {
         let tmp_dir = test_util::tests::setup();
 
-        let (mut command_receiver, p2p_client) = create_p2p_client();
+        let keypair = Keypair::generate();
+
+        let (mut command_receiver, p2p_client) = create_p2p_client(&keypair);
         let (_build_event_receiver, mut artifact_service) =
-            create_artifact_service(&tmp_dir, p2p_client.clone());
+            create_artifact_service(&tmp_dir, &keypair, p2p_client.clone());
 
         tokio::spawn(async move {
             loop {
@@ -355,7 +348,7 @@ mod tests {
         let package_specific_artifact_id = "package_specific_artifact_id";
         let transparency_log = artifact_service
             .transparency_log_service
-            .create_add_artifact(AddArtifactRequest {
+            .add_artifact(AddArtifactRequest {
                 package_type,
                 package_specific_id: package_specific_id.to_owned(),
                 num_artifacts: 8,
@@ -404,9 +397,11 @@ mod tests {
     async fn test_get_from_peers() {
         let tmp_dir = test_util::tests::setup();
 
-        let (mut command_receiver, p2p_client) = create_p2p_client();
+        let keypair = Keypair::generate();
+
+        let (mut command_receiver, p2p_client) = create_p2p_client(&keypair);
         let (_build_event_receiver, mut artifact_service) =
-            create_artifact_service(&tmp_dir, p2p_client.clone());
+            create_artifact_service(&tmp_dir, &keypair, p2p_client.clone());
 
         tokio::spawn(async move {
             loop {
@@ -441,7 +436,7 @@ mod tests {
         let package_specific_artifact_id = "package_specific_artifact_id";
         let transparency_log = artifact_service
             .transparency_log_service
-            .create_add_artifact(AddArtifactRequest {
+            .add_artifact(AddArtifactRequest {
                 package_type,
                 package_specific_id: package_specific_id.to_owned(),
                 num_artifacts: 8,
@@ -470,9 +465,11 @@ mod tests {
     async fn test_get_from_peers_with_no_providers() {
         let tmp_dir = test_util::tests::setup();
 
-        let (mut command_receiver, p2p_client) = create_p2p_client();
+        let keypair = Keypair::generate();
+
+        let (mut command_receiver, p2p_client) = create_p2p_client(&keypair);
         let (_build_event_receiver, mut artifact_service) =
-            create_artifact_service(&tmp_dir, p2p_client.clone());
+            create_artifact_service(&tmp_dir, &keypair, p2p_client.clone());
 
         tokio::spawn(async move {
             tokio::select! {
@@ -503,9 +500,11 @@ mod tests {
     async fn test_verify_artifact_succeeds_when_hashes_same() {
         let tmp_dir = test_util::tests::setup();
 
-        let (mut command_receiver, p2p_client) = create_p2p_client();
+        let keypair = Keypair::generate();
+
+        let (mut command_receiver, p2p_client) = create_p2p_client(&keypair);
         let (_build_event_receiver, mut artifact_service) =
-            create_artifact_service(&tmp_dir, p2p_client.clone());
+            create_artifact_service(&tmp_dir, &keypair, p2p_client.clone());
 
         tokio::spawn(async move {
             loop {
@@ -527,7 +526,7 @@ mod tests {
         let package_specific_artifact_id = "package_specific_artifact_id";
         let created_transparency_log = artifact_service
             .transparency_log_service
-            .create_add_artifact(AddArtifactRequest {
+            .add_artifact(AddArtifactRequest {
                 package_type,
                 package_specific_id: package_specific_id.to_owned(),
                 num_artifacts: 8,
@@ -558,9 +557,11 @@ mod tests {
     async fn test_verify_artifact_fails_when_hashes_differ() {
         let tmp_dir = test_util::tests::setup();
 
-        let (mut command_receiver, p2p_client) = create_p2p_client();
+        let keypair = Keypair::generate();
+
+        let (mut command_receiver, p2p_client) = create_p2p_client(&keypair);
         let (_build_event_receiver, mut artifact_service) =
-            create_artifact_service(&tmp_dir, p2p_client.clone());
+            create_artifact_service(&tmp_dir, &keypair, p2p_client.clone());
 
         tokio::spawn(async move {
             loop {
@@ -586,7 +587,7 @@ mod tests {
         let package_specific_artifact_id = "package_specific_artifact_id";
         let created_transparency_log = artifact_service
             .transparency_log_service
-            .create_add_artifact(AddArtifactRequest {
+            .add_artifact(AddArtifactRequest {
                 package_type,
                 package_specific_id: package_specific_id.to_owned(),
                 num_artifacts: 8,
@@ -625,9 +626,11 @@ mod tests {
     async fn test_get_artifact_logs() {
         let tmp_dir = test_util::tests::setup();
 
-        let (mut command_receiver, p2p_client) = create_p2p_client();
+        let keypair = Keypair::generate();
+
+        let (mut command_receiver, p2p_client) = create_p2p_client(&keypair);
         let (_build_event_receiver, mut artifact_service) =
-            create_artifact_service(&tmp_dir, p2p_client.clone());
+            create_artifact_service(&tmp_dir, &keypair, p2p_client.clone());
 
         tokio::spawn(async move {
             loop {
@@ -648,7 +651,7 @@ mod tests {
         let package_specific_artifact_id = "package_specific_artifact_id";
         let transparency_log = artifact_service
             .transparency_log_service
-            .create_add_artifact(AddArtifactRequest {
+            .add_artifact(AddArtifactRequest {
                 package_type,
                 package_specific_id: package_specific_id.to_owned(),
                 num_artifacts: 8,

--- a/src/build_service/mapping/service.rs
+++ b/src/build_service/mapping/service.rs
@@ -18,6 +18,7 @@ use super::model::MappingInfo;
 use crate::artifact_service::model::PackageType;
 use crate::build_service::error::BuildError;
 
+#[derive(Clone)]
 pub struct MappingService {
     mapping_service_endpoint: String,
 }

--- a/src/build_service/pipeline/service.rs
+++ b/src/build_service/pipeline/service.rs
@@ -192,8 +192,7 @@ mod tests {
 
         let pipeline_service = PipelineService::new(&http_server.url("/").to_string());
 
-        let a = pipeline_service.start_build(mapping_info).await.unwrap();
-        println!("ID: {:?}", a);
+        pipeline_service.start_build(mapping_info).await.unwrap();
     }
 
     #[tokio::test]

--- a/src/build_service/service.rs
+++ b/src/build_service/service.rs
@@ -29,6 +29,7 @@ use std::path::{Path, PathBuf};
 
 /// The build service is a component used by authorized nodes only. It is
 /// the entrypoint to the authorized node's build pipeline infrastructure.
+#[derive(Clone)]
 pub struct BuildService {
     repository_path: PathBuf,
     build_event_client: BuildEventClient,

--- a/src/docker/v2/handlers/blobs.rs
+++ b/src/docker/v2/handlers/blobs.rs
@@ -19,20 +19,16 @@ use crate::artifact_service::service::ArtifactService;
 use crate::docker::error_util::{RegistryError, RegistryErrorCode};
 use log::debug;
 use std::result::Result;
-use std::sync::Arc;
-use tokio::sync::Mutex;
 use warp::{http::StatusCode, Rejection, Reply};
 
 pub async fn handle_get_blobs(
     name: String,
     digest: String,
-    artifact_service: Arc<Mutex<ArtifactService>>,
+    mut artifact_service: ArtifactService,
 ) -> Result<impl Reply, Rejection> {
     debug!("Getting blob with digest: {:?}", digest);
 
     let blob_content = artifact_service
-        .lock()
-        .await
         .get_artifact(
             PackageType::Docker,
             &get_package_specific_artifact_id(&name, &digest),
@@ -64,15 +60,17 @@ mod tests {
     use crate::build_service::event::BuildEventClient;
     use crate::network::client::command::Command;
     use crate::network::client::Client;
-    use crate::transparency_log::log::AddArtifactRequest;
+    use crate::transparency_log::log::{AddArtifactRequest, TransparencyLogService};
     use crate::util::test_util;
     use anyhow::Context;
     use hyper::header::HeaderValue;
     use libp2p::identity::Keypair;
     use std::borrow::Borrow;
+    use std::collections::HashSet;
     use std::fs::File;
-    use std::path::PathBuf;
-    use tokio::sync::mpsc;
+    use std::path::{Path, PathBuf};
+    use std::sync::Arc;
+    use tokio::sync::{mpsc, Mutex};
 
     fn create_p2p_client(local_keypair: &Keypair) -> (mpsc::Receiver<Command>, Client) {
         let (command_sender, command_receiver) = mpsc::channel(1);
@@ -95,6 +93,17 @@ mod tests {
         BlockchainService::new(ed25519_keypair, p2p_client)
     }
 
+    fn create_transparency_log_service<P: AsRef<Path>>(
+        artifact_path: P,
+        local_keypair: Keypair,
+        p2p_client: Client,
+    ) -> TransparencyLogService {
+        let blockchain_service = create_blockchain_service(&local_keypair, p2p_client);
+
+        TransparencyLogService::new(artifact_path, Arc::new(Mutex::new(blockchain_service)))
+            .expect("Creating TransparencyLogService failed")
+    }
+
     #[test]
     fn test_get_package_specific_artifact_id_from_digest() {
         let name = "alpine";
@@ -115,25 +124,20 @@ mod tests {
 
         let local_keypair = Keypair::generate_ed25519();
         let (_command_receiver, p2p_client) = create_p2p_client(&local_keypair);
-        let blockchain_service = create_blockchain_service(&local_keypair, p2p_client.clone());
+        let transparency_log_service =
+            create_transparency_log_service(&tmp_dir, local_keypair, p2p_client.clone());
 
         let (build_event_sender, _build_event_receiver) = mpsc::channel(1);
         let build_event_client = BuildEventClient::new(build_event_sender);
         let artifact_service = ArtifactService::new(
             &tmp_dir,
-            local_keypair,
-            blockchain_service,
+            transparency_log_service,
             build_event_client,
             p2p_client,
         )
         .expect("Creating ArtifactService failed");
 
-        let result = handle_get_blobs(
-            name.to_owned(),
-            hash.to_owned(),
-            Arc::new(Mutex::new(artifact_service)),
-        )
-        .await;
+        let result = handle_get_blobs(name.to_owned(), hash.to_owned(), artifact_service).await;
 
         assert!(result.is_err());
         let rejection = result.err().unwrap();
@@ -160,15 +164,26 @@ mod tests {
         let package_specific_artifact_id = get_package_specific_artifact_id(name, &digest);
 
         let local_keypair = Keypair::generate_ed25519();
-        let (_command_receiver, p2p_client) = create_p2p_client(&local_keypair);
-        let blockchain_service = create_blockchain_service(&local_keypair, p2p_client.clone());
+        let (mut command_receiver, p2p_client) = create_p2p_client(&local_keypair);
+        let transparency_log_service =
+            create_transparency_log_service(&tmp_dir, local_keypair, p2p_client.clone());
+
+        tokio::spawn(async move {
+            loop {
+                match command_receiver.recv().await {
+                    Some(Command::ListPeers { sender, .. }) => {
+                        let _ = sender.send(HashSet::new());
+                    }
+                    _ => panic!("Command must match Command::ListPeers"),
+                }
+            }
+        });
 
         let (build_event_sender, _build_event_receiver) = mpsc::channel(1);
         let build_event_client = BuildEventClient::new(build_event_sender);
         let mut artifact_service = ArtifactService::new(
             &tmp_dir,
-            local_keypair,
-            blockchain_service,
+            transparency_log_service,
             build_event_client,
             p2p_client,
         )
@@ -176,7 +191,7 @@ mod tests {
 
         let transparency_log = artifact_service
             .transparency_log_service
-            .create_add_artifact(AddArtifactRequest {
+            .add_artifact(AddArtifactRequest {
                 package_type,
                 package_specific_id,
                 num_artifacts: 8,
@@ -196,12 +211,7 @@ mod tests {
         )
         .unwrap();
 
-        let result = handle_get_blobs(
-            name.to_owned(),
-            digest,
-            Arc::new(Mutex::new(artifact_service)),
-        )
-        .await;
+        let result = handle_get_blobs(name.to_owned(), digest, artifact_service).await;
 
         assert!(result.is_ok());
 

--- a/src/java/maven2/routes.rs
+++ b/src/java/maven2/routes.rs
@@ -17,12 +17,10 @@
 use super::handlers::maven_artifacts::handle_get_maven_artifact;
 use crate::artifact_service::service::ArtifactService;
 use log::debug;
-use std::sync::Arc;
-use tokio::sync::Mutex;
 use warp::Filter;
 
 pub fn make_maven_routes(
-    artifact_service: Arc<Mutex<ArtifactService>>,
+    artifact_service: ArtifactService,
 ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
     let artifact_service_filter = warp::any().map(move || artifact_service.clone());
 
@@ -49,11 +47,13 @@ mod tests {
     use crate::docker::error_util::RegistryError;
     use crate::network::client::command::Command;
     use crate::network::client::Client;
-    use crate::transparency_log::log::TransparencyLogError;
+    use crate::transparency_log::log::{TransparencyLogError, TransparencyLogService};
     use crate::util::test_util;
     use libp2p::identity::Keypair;
+    use std::path::Path;
     use std::str;
-    use tokio::sync::mpsc;
+    use std::sync::Arc;
+    use tokio::sync::{mpsc, Mutex};
 
     fn create_p2p_client(local_keypair: &Keypair) -> (mpsc::Receiver<Command>, Client) {
         let (command_sender, command_receiver) = mpsc::channel(1);
@@ -76,26 +76,37 @@ mod tests {
         BlockchainService::new(ed25519_keypair, p2p_client)
     }
 
+    fn create_transparency_log_service<P: AsRef<Path>>(
+        artifact_path: P,
+        local_keypair: Keypair,
+        p2p_client: Client,
+    ) -> TransparencyLogService {
+        let blockchain_service = create_blockchain_service(&local_keypair, p2p_client);
+
+        TransparencyLogService::new(artifact_path, Arc::new(Mutex::new(blockchain_service)))
+            .expect("Creating TransparencyLogService failed")
+    }
+
     #[tokio::test]
     async fn maven_routes() {
         let tmp_dir = test_util::tests::setup();
 
         let local_keypair = Keypair::generate_ed25519();
         let (_command_receiver, p2p_client) = create_p2p_client(&local_keypair);
-        let blockchain_service = create_blockchain_service(&local_keypair, p2p_client.clone());
+        let transparency_log_service =
+            create_transparency_log_service(&tmp_dir, local_keypair, p2p_client.clone());
 
         let (build_event_sender, _build_event_receiver) = mpsc::channel(1);
         let build_event_client = BuildEventClient::new(build_event_sender);
         let artifact_service = ArtifactService::new(
             &tmp_dir,
-            local_keypair,
-            blockchain_service,
+            transparency_log_service,
             build_event_client,
             p2p_client,
         )
         .expect("Creating ArtifactService failed");
 
-        let filter = make_maven_routes(Arc::new(Mutex::new(artifact_service)));
+        let filter = make_maven_routes(artifact_service);
         let response = warp::test::request()
             .path("/maven2/com/company/artifact/1.8/artifact-1.8.pom")
             .reply(&filter)

--- a/src/network/event_loop.rs
+++ b/src/network/event_loop.rs
@@ -111,7 +111,7 @@ impl PyrsiaEventLoop {
 
     // Handles events from the `AutoNat` network behaviour.
     async fn handle_autonat_event(&mut self, event: AutonatEvent) {
-        println!("Handle AutonatEvent: {:?}", event);
+        trace!("Handle AutonatEvent: {:?}", event);
         match event {
             AutonatEvent::InboundProbe(evt) => {
                 debug!("AutonatEvent::InboundProbe {:?}", evt);

--- a/src/node_api/handlers/swarm.rs
+++ b/src/node_api/handlers/swarm.rs
@@ -15,25 +15,23 @@
 */
 
 use crate::artifact_service::model::PackageType;
-use crate::artifact_service::service::ArtifactService;
+use crate::build_service::event::BuildEventClient;
 use crate::docker::error_util::RegistryError;
+use crate::network::client::Client;
 use crate::node_api::model::cli::{
     RequestDockerBuild, RequestDockerLog, RequestMavenBuild, RequestMavenLog,
 };
+use crate::transparency_log::log::TransparencyLogService;
 
 use log::debug;
-use std::sync::Arc;
-use tokio::sync::Mutex;
 use warp::{http::StatusCode, Rejection, Reply};
 
 pub async fn handle_build_docker(
     request_docker_build: RequestDockerBuild,
-    artifact_service: Arc<Mutex<ArtifactService>>,
+    build_event_client: BuildEventClient,
 ) -> Result<impl Reply, Rejection> {
-    let build_id = artifact_service
-        .lock()
-        .await
-        .request_build(PackageType::Docker, request_docker_build.image)
+    let build_id = build_event_client
+        .start_build(PackageType::Docker, request_docker_build.image)
         .await
         .map_err(RegistryError::from)?;
 
@@ -47,12 +45,10 @@ pub async fn handle_build_docker(
 
 pub async fn handle_build_maven(
     request_maven_build: RequestMavenBuild,
-    artifact_service: Arc<Mutex<ArtifactService>>,
+    build_event_client: BuildEventClient,
 ) -> Result<impl Reply, Rejection> {
-    let build_id = artifact_service
-        .lock()
-        .await
-        .request_build(PackageType::Maven2, request_maven_build.gav)
+    let build_id = build_event_client
+        .start_build(PackageType::Maven2, request_maven_build.gav)
         .await
         .map_err(RegistryError::from)?;
 
@@ -64,16 +60,8 @@ pub async fn handle_build_maven(
         .body(build_id_as_json))
 }
 
-pub async fn handle_get_peers(
-    artifact_service: Arc<Mutex<ArtifactService>>,
-) -> Result<impl Reply, Rejection> {
-    let peers = artifact_service
-        .lock()
-        .await
-        .p2p_client
-        .list_peers()
-        .await
-        .map_err(RegistryError::from)?;
+pub async fn handle_get_peers(mut p2p_client: Client) -> Result<impl Reply, Rejection> {
+    let peers = p2p_client.list_peers().await.map_err(RegistryError::from)?;
     debug!("Got received_peers: {:?}", peers);
 
     let str_peers: Vec<String> = peers.into_iter().map(|p| p.to_string()).collect();
@@ -86,16 +74,8 @@ pub async fn handle_get_peers(
         .unwrap())
 }
 
-pub async fn handle_get_status(
-    artifact_service: Arc<Mutex<ArtifactService>>,
-) -> Result<impl Reply, Rejection> {
-    let mut artifact_service = artifact_service.lock().await;
-
-    let status = artifact_service
-        .p2p_client
-        .status()
-        .await
-        .map_err(RegistryError::from)?;
+pub async fn handle_get_status(mut p2p_client: Client) -> Result<impl Reply, Rejection> {
+    let status = p2p_client.status().await.map_err(RegistryError::from)?;
 
     let status_as_json = serde_json::to_string(&status).unwrap();
 
@@ -108,13 +88,10 @@ pub async fn handle_get_status(
 
 pub async fn handle_inspect_log_docker(
     request_docker_log: RequestDockerLog,
-    artifact_service: Arc<Mutex<ArtifactService>>,
+    transparency_log_service: TransparencyLogService,
 ) -> Result<impl Reply, Rejection> {
-    let result = artifact_service
-        .lock()
-        .await
-        .get_logs_for_artifact(PackageType::Docker, &request_docker_log.image)
-        .await
+    let result = transparency_log_service
+        .search_transparency_logs(&PackageType::Docker, &request_docker_log.image)
         .map_err(RegistryError::from)?;
 
     let result_as_json = serde_json::to_string(&result).map_err(RegistryError::from)?;
@@ -128,13 +105,10 @@ pub async fn handle_inspect_log_docker(
 
 pub async fn handle_inspect_log_maven(
     request_maven_log: RequestMavenLog,
-    artifact_service: Arc<Mutex<ArtifactService>>,
+    transparency_log_service: TransparencyLogService,
 ) -> Result<impl Reply, Rejection> {
-    let result = artifact_service
-        .lock()
-        .await
-        .get_logs_for_artifact(PackageType::Maven2, &request_maven_log.gav)
-        .await
+    let result = transparency_log_service
+        .search_transparency_logs(&PackageType::Maven2, &request_maven_log.gav)
         .map_err(RegistryError::from)?;
 
     let result_as_json = serde_json::to_string(&result).map_err(RegistryError::from)?;

--- a/src/node_api/routes.rs
+++ b/src/node_api/routes.rs
@@ -16,23 +16,27 @@
 
 use super::handlers::swarm::*;
 use super::model::cli::{RequestDockerBuild, RequestMavenBuild};
-use crate::artifact_service::service::ArtifactService;
+use crate::build_service::event::BuildEventClient;
+use crate::network::client::Client;
 use crate::node_api::model::cli::{RequestDockerLog, RequestMavenLog};
-use std::sync::Arc;
-use tokio::sync::Mutex;
+use crate::transparency_log::log::TransparencyLogService;
 use warp::Filter;
 
 pub fn make_node_routes(
-    artifact_service: Arc<Mutex<ArtifactService>>,
+    build_event_client: BuildEventClient,
+    p2p_client: Client,
+    transparency_log_service: TransparencyLogService,
 ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
-    let artifact_service_filter = warp::any().map(move || artifact_service.clone());
+    let build_event_client_filter = warp::any().map(move || build_event_client.clone());
+    let p2p_client_filter = warp::any().map(move || p2p_client.clone());
+    let transparency_log_service_filter = warp::any().map(move || transparency_log_service.clone());
 
     let build_docker = warp::path!("build" / "docker")
         .and(warp::post())
         .and(warp::path::end())
         .and(warp::body::content_length_limit(1024 * 8))
         .and(warp::body::json::<RequestDockerBuild>())
-        .and(artifact_service_filter.clone())
+        .and(build_event_client_filter.clone())
         .and_then(handle_build_docker);
 
     let build_maven = warp::path!("build" / "maven")
@@ -40,19 +44,19 @@ pub fn make_node_routes(
         .and(warp::path::end())
         .and(warp::body::content_length_limit(1024 * 8))
         .and(warp::body::json::<RequestMavenBuild>())
-        .and(artifact_service_filter.clone())
+        .and(build_event_client_filter)
         .and_then(handle_build_maven);
 
     let peers = warp::path!("peers")
         .and(warp::get())
         .and(warp::path::end())
-        .and(artifact_service_filter.clone())
+        .and(p2p_client_filter.clone())
         .and_then(handle_get_peers);
 
     let status = warp::path!("status")
         .and(warp::get())
         .and(warp::path::end())
-        .and(artifact_service_filter.clone())
+        .and(p2p_client_filter)
         .and_then(handle_get_status);
 
     let inspect_docker = warp::path!("inspect" / "docker")
@@ -60,7 +64,7 @@ pub fn make_node_routes(
         .and(warp::path::end())
         .and(warp::body::content_length_limit(1024 * 8))
         .and(warp::body::json::<RequestDockerLog>())
-        .and(artifact_service_filter.clone())
+        .and(transparency_log_service_filter.clone())
         .and_then(handle_inspect_log_docker);
 
     let inspect_maven = warp::path!("inspect" / "maven")
@@ -68,7 +72,7 @@ pub fn make_node_routes(
         .and(warp::path::end())
         .and(warp::body::content_length_limit(1024 * 8))
         .and(warp::body::json::<RequestMavenLog>())
-        .and(artifact_service_filter)
+        .and(transparency_log_service_filter)
         .and_then(handle_inspect_log_maven);
 
     warp::any().and(
@@ -95,7 +99,8 @@ mod tests {
     use std::collections::HashSet;
     use std::path::Path;
     use std::str;
-    use tokio::sync::mpsc;
+    use std::sync::Arc;
+    use tokio::sync::{mpsc, Mutex};
 
     fn create_p2p_client(local_keypair: &Keypair) -> (mpsc::Receiver<Command>, Client) {
         let (command_sender, command_receiver) = mpsc::channel(1);
@@ -118,26 +123,24 @@ mod tests {
         BlockchainService::new(ed25519_keypair, p2p_client)
     }
 
-    fn create_artifact_service<P: AsRef<Path>>(
+    fn create_build_event_client() -> (mpsc::Receiver<BuildEvent>, BuildEventClient) {
+        let (build_event_sender, build_event_receiver) = mpsc::channel(1);
+
+        (
+            build_event_receiver,
+            BuildEventClient::new(build_event_sender),
+        )
+    }
+
+    fn create_transparency_log_service<P: AsRef<Path>>(
         artifact_path: P,
         local_keypair: Keypair,
         p2p_client: Client,
-    ) -> (mpsc::Receiver<BuildEvent>, ArtifactService) {
-        let blockchain_service = create_blockchain_service(&local_keypair, p2p_client.clone());
+    ) -> TransparencyLogService {
+        let blockchain_service = create_blockchain_service(&local_keypair, p2p_client);
 
-        let (build_event_sender, build_event_receiver) = mpsc::channel(1);
-        let build_event_client = BuildEventClient::new(build_event_sender);
-
-        let artifact_service = ArtifactService::new(
-            &artifact_path,
-            local_keypair,
-            blockchain_service,
-            build_event_client,
-            p2p_client,
-        )
-        .expect("Creating ArtifactService failed");
-
-        (build_event_receiver, artifact_service)
+        TransparencyLogService::new(artifact_path, Arc::new(Mutex::new(blockchain_service)))
+            .expect("Creating ArtifactService failed")
     }
 
     #[tokio::test]
@@ -146,8 +149,9 @@ mod tests {
 
         let local_keypair = Keypair::generate_ed25519();
         let (_command_receiver, p2p_client) = create_p2p_client(&local_keypair);
-        let (mut build_event_receiver, artifact_service) =
-            create_artifact_service(&tmp_dir, local_keypair, p2p_client);
+        let (mut build_event_receiver, build_event_client) = create_build_event_client();
+        let transparency_log_service =
+            create_transparency_log_service(&tmp_dir, local_keypair, p2p_client.clone());
 
         let build_id = uuid::Uuid::new_v4();
         tokio::spawn(async move {
@@ -161,7 +165,7 @@ mod tests {
             }
         });
 
-        let filter = make_node_routes(Arc::new(Mutex::new(artifact_service)));
+        let filter = make_node_routes(build_event_client, p2p_client, transparency_log_service);
         let request = RequestDockerBuild {
             image: "alpine:3.15.2".to_owned(),
         };
@@ -186,8 +190,9 @@ mod tests {
 
         let local_keypair = Keypair::generate_ed25519();
         let (_command_receiver, p2p_client) = create_p2p_client(&local_keypair);
-        let (mut build_event_receiver, artifact_service) =
-            create_artifact_service(&tmp_dir, local_keypair, p2p_client);
+        let (mut build_event_receiver, build_event_client) = create_build_event_client();
+        let transparency_log_service =
+            create_transparency_log_service(&tmp_dir, local_keypair, p2p_client.clone());
 
         let build_id = uuid::Uuid::new_v4();
         tokio::spawn(async move {
@@ -201,7 +206,7 @@ mod tests {
             }
         });
 
-        let filter = make_node_routes(Arc::new(Mutex::new(artifact_service)));
+        let filter = make_node_routes(build_event_client, p2p_client, transparency_log_service);
         let request = RequestMavenBuild {
             gav: "commons-codec:commons-codec:1.15".to_owned(),
         };
@@ -226,8 +231,9 @@ mod tests {
 
         let local_keypair = Keypair::generate_ed25519();
         let (mut command_receiver, p2p_client) = create_p2p_client(&local_keypair);
-        let (_build_event_receiver, artifact_service) =
-            create_artifact_service(&tmp_dir, local_keypair, p2p_client.clone());
+        let (_build_event_receiver, build_event_client) = create_build_event_client();
+        let transparency_log_service =
+            create_transparency_log_service(&tmp_dir, local_keypair, p2p_client.clone());
 
         tokio::spawn(async move {
             loop {
@@ -242,7 +248,11 @@ mod tests {
             }
         });
 
-        let filter = make_node_routes(Arc::new(Mutex::new(artifact_service)));
+        let filter = make_node_routes(
+            build_event_client,
+            p2p_client.clone(),
+            transparency_log_service,
+        );
         let response = warp::test::request().path("/peers").reply(&filter).await;
 
         let expected_body =
@@ -260,8 +270,9 @@ mod tests {
 
         let local_keypair = Keypair::generate_ed25519();
         let (mut command_receiver, p2p_client) = create_p2p_client(&local_keypair);
-        let (_build_event_receiver, artifact_service) =
-            create_artifact_service(&tmp_dir, local_keypair, p2p_client.clone());
+        let (_build_event_receiver, build_event_client) = create_build_event_client();
+        let transparency_log_service =
+            create_transparency_log_service(&tmp_dir, local_keypair, p2p_client.clone());
 
         tokio::spawn(async move {
             loop {
@@ -285,7 +296,11 @@ mod tests {
             }
         });
 
-        let filter = make_node_routes(Arc::new(Mutex::new(artifact_service)));
+        let filter = make_node_routes(
+            build_event_client,
+            p2p_client.clone(),
+            transparency_log_service,
+        );
         let response = warp::test::request().path("/status").reply(&filter).await;
 
         let expected_status = Status {

--- a/src/transparency_log/log.rs
+++ b/src/transparency_log/log.rs
@@ -15,6 +15,7 @@
 */
 
 use crate::artifact_service::model::PackageType;
+use crate::blockchain_service::service::BlockchainService;
 use libp2p::PeerId;
 use log::{debug, error};
 use rusqlite::types::{ToSqlOutput, Value};
@@ -24,8 +25,10 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use thiserror::Error;
+use tokio::sync::Mutex;
 use uuid::Uuid;
 
 #[derive(Debug, Clone, Error, Eq, PartialEq)]
@@ -128,16 +131,22 @@ pub struct AuthorizedNode {
 ///
 /// It uses a local database to store and index transparency log information to simplify
 /// access.
+#[derive(Clone)]
 pub struct TransparencyLogService {
     storage_path: PathBuf,
+    blockchain_service: Arc<Mutex<BlockchainService>>,
 }
 
 impl TransparencyLogService {
-    pub fn new<P: AsRef<Path>>(repository_path: P) -> Result<Self, TransparencyLogError> {
+    pub fn new<P: AsRef<Path>>(
+        repository_path: P,
+        blockchain_service: Arc<Mutex<BlockchainService>>,
+    ) -> Result<Self, TransparencyLogError> {
         let mut absolute_path = repository_path.as_ref().to_path_buf().canonicalize()?;
         absolute_path.push("transparency_log");
         Ok(TransparencyLogService {
             storage_path: absolute_path,
+            blockchain_service,
         })
     }
 
@@ -152,7 +161,7 @@ impl TransparencyLogService {
     }
 
     /// Adds a transparency log with the AddArtifact operation.
-    pub async fn create_add_artifact(
+    pub async fn add_artifact(
         &mut self,
         add_artifact_request: AddArtifactRequest,
     ) -> Result<TransparencyLog, TransparencyLogError> {
@@ -174,6 +183,13 @@ impl TransparencyLogService {
             node_id: Uuid::new_v4().to_string(),
             node_public_key: Uuid::new_v4().to_string(),
         };
+
+        let payload = serde_json::to_string(&transparency_log).unwrap();
+        self.blockchain_service
+            .lock()
+            .await
+            .add_payload(payload.into_bytes())
+            .await;
 
         Ok(transparency_log)
     }
@@ -424,7 +440,29 @@ impl TransparencyLogService {
 #[cfg(not(tarpaulin_include))]
 mod tests {
     use super::*;
-    use crate::util::test_util;
+    use crate::{network::client::Client, util::test_util};
+    use libp2p::identity;
+    use tokio::sync::mpsc;
+
+    fn create_p2p_client(keypair: identity::Keypair) -> Client {
+        let (command_sender, _command_receiver) = mpsc::channel(1);
+        Client {
+            sender: command_sender,
+            local_peer_id: keypair.public().to_peer_id(),
+        }
+    }
+
+    fn create_transparency_log_service<P: AsRef<Path>>(artifact_path: P) -> TransparencyLogService {
+        let ed25519_keypair = identity::ed25519::Keypair::generate();
+        let p2p_client = create_p2p_client(identity::Keypair::Ed25519(ed25519_keypair.clone()));
+
+        let blockchain_service = Arc::new(Mutex::new(BlockchainService::new(
+            &ed25519_keypair,
+            p2p_client,
+        )));
+
+        TransparencyLogService::new(&artifact_path, blockchain_service).unwrap()
+    }
 
     #[test]
     fn create_transparency_log() {
@@ -473,10 +511,6 @@ mod tests {
         assert_eq!(transparency_log.operation, operation);
         assert_eq!(transparency_log.node_id, node_id);
         assert_eq!(transparency_log.node_public_key, node_public_key);
-    }
-
-    fn create_transparency_log_service<P: AsRef<Path>>(artifact_path: P) -> TransparencyLogService {
-        TransparencyLogService::new(&artifact_path).unwrap()
     }
 
     #[test]
@@ -774,13 +808,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_create_add_artifact() {
+    async fn test_add_artifact() {
         let tmp_dir = test_util::tests::setup();
 
         let mut log = create_transparency_log_service(&tmp_dir);
 
         let result = log
-            .create_add_artifact(AddArtifactRequest {
+            .add_artifact(AddArtifactRequest {
                 package_type: PackageType::Docker,
                 package_specific_id: "package_specific_id".to_owned(),
                 num_artifacts: 8,


### PR DESCRIPTION
## Description

Fixes #988

This PR fixes an issue where incoming requests to the pyrsia node could be blocked, waiting to get a mutex lock on the artifact service. It does this by removing the usage of Mutex where possible. The only place where we still use one, is for passing around an instance of the BlockchainService. The other services that don't have any reference to memory can safely be cloned. The rest of the services that do have data are only accessed from a single place in code and don't need to be shared.

## PR Checklist

<!-- Make certain you've done the following. -->

- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/get_involved/good_pr.md)
- [x] I've included a good title and brief description along with how to review them.
- [x] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).

### Code Contributions

<!--

This section applies to code modifications, you may remove it otherwise.

Make sure your Pull Request will pass the CI/CD pipeline.
For a complete list of steps, check out the [developer workflow](https://github.com/pyrsia/pyrsia/blob/main/docs/get_involved/dev_workflow.md)!

-->

- [x] I've built the code `cargo build --all-targets` successfully.
- [x] I've run the unit tests `cargo test --workspace` and everything passes.
- [x] I've made sure my rust toolchain is current `rustup update`.
