### PR TITLE
Trigger build only on authorized node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ target/
 .DS_Store
 /src/blockchain/blockchain_storage
 tests/reports/
+nodeA
+nodeB
+p2p_keypair.ser

--- a/pyrsia_node/src/main.rs
+++ b/pyrsia_node/src/main.rs
@@ -74,7 +74,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         &args,
         artifact_service.clone(),
         transparency_log_service,
-        build_event_client.clone(),
         p2p_client.clone(),
     );
 
@@ -318,7 +317,6 @@ fn setup_http(
     args: &PyrsiaNodeArgs,
     artifact_service: ArtifactService,
     transparency_log_service: TransparencyLogService,
-    build_event_client: BuildEventClient,
     p2p_client: Client,
 ) {
     // Get host and port from the settings. Defaults to DEFAULT_HOST and DEFAULT_PORT
@@ -334,9 +332,8 @@ fn setup_http(
 
     debug!("Setup HTTP routing");
     let docker_routes = make_docker_routes(artifact_service.clone());
-    let maven_routes = make_maven_routes(artifact_service);
-    let node_api_routes =
-        make_node_routes(build_event_client, p2p_client, transparency_log_service);
+    let maven_routes = make_maven_routes(artifact_service.clone());
+    let node_api_routes = make_node_routes(artifact_service, p2p_client, transparency_log_service);
     let all_routes = docker_routes.or(maven_routes).or(node_api_routes);
 
     debug!("Setup HTTP server");

--- a/pyrsia_node/src/main.rs
+++ b/pyrsia_node/src/main.rs
@@ -230,7 +230,7 @@ async fn setup_pyrsia_services(
     blockchain_service: BlockchainService,
     p2p_client: Client,
     args: &PyrsiaNodeArgs,
-) -> Result<(Arc<Mutex<ArtifactService>>, Arc<Mutex<BuildEventClient>>)> {
+) -> Result<(Arc<Mutex<ArtifactService>>, BuildEventClient)> {
     let artifact_path = PathBuf::from(ARTIFACTS_DIR.as_str());
     let (build_event_sender, build_event_receiver) = mpsc::channel(32);
     let build_event_client = BuildEventClient::new(build_event_sender);
@@ -258,7 +258,7 @@ async fn setup_pyrsia_services(
     );
     tokio::spawn(build_event_loop.run());
 
-    Ok((artifact_service, Arc::new(Mutex::new(build_event_client))))
+    Ok((artifact_service, build_event_client))
 }
 
 fn setup_artifact_service(

--- a/pyrsia_node/src/network/handlers.rs
+++ b/pyrsia_node/src/network/handlers.rs
@@ -76,7 +76,7 @@ pub async fn handle_request_artifact(
 /// Respond to a RequestBuild event by getting the build
 /// based on the provided package_type and package_specific_id.
 pub async fn handle_request_build(
-    build_event_client: Arc<Mutex<BuildEventClient>>,
+    build_event_client: BuildEventClient,
     package_type: PackageType,
     package_specific_id: &str,
     _: ResponseChannel<BuildResponse>,
@@ -86,8 +86,7 @@ pub async fn handle_request_build(
         package_type, package_specific_id
     );
 
-    let build_event = build_event_client.lock().await;
-    build_event
+    build_event_client
         .start_build(package_type, package_specific_id.to_string())
         .await
 }

--- a/src/artifact_service/service.rs
+++ b/src/artifact_service/service.rs
@@ -73,7 +73,10 @@ impl ArtifactService {
         package_type: PackageType,
         package_specific_id: String,
     ) -> Result<String, BuildError> {
-        debug!("Request build of {:?} {:?}", package_type, package_specific_id);
+        debug!(
+            "Request build of {:?} {:?}",
+            package_type, package_specific_id
+        );
 
         let local_peer_id = self.local_keypair.public().to_peer_id();
         debug!("Got local node with peer_id: {:?}", local_peer_id.clone());

--- a/src/network.rs
+++ b/src/network.rs
@@ -17,6 +17,7 @@
 pub mod artifact_protocol;
 pub mod behaviour;
 pub mod blockchain_protocol;
+pub mod build_protocol;
 pub mod client;
 pub mod event_loop;
 pub mod idle_metric_protocol;

--- a/src/network/behaviour.rs
+++ b/src/network/behaviour.rs
@@ -22,6 +22,7 @@ use crate::network::idle_metric_protocol::{
     IdleMetricExchangeCodec, IdleMetricRequest, IdleMetricResponse,
 };
 
+use crate::network::build_protocol::{BuildExchangeCodec, BuildRequest, BuildResponse};
 use libp2p::autonat;
 use libp2p::identify::{Identify, IdentifyEvent};
 use libp2p::kad::record::store::MemoryStore;
@@ -44,6 +45,7 @@ pub struct PyrsiaNetworkBehaviour {
     pub identify: Identify,
     pub kademlia: Kademlia<MemoryStore>,
     pub request_response: RequestResponse<ArtifactExchangeCodec>,
+    pub build_request_response: RequestResponse<BuildExchangeCodec>,
     pub idle_metric_request_response: RequestResponse<IdleMetricExchangeCodec>,
     pub block_update_request_response: RequestResponse<BlockUpdateExchangeCodec>,
 }
@@ -56,6 +58,7 @@ pub enum PyrsiaNetworkEvent {
     Identify(IdentifyEvent),
     Kademlia(KademliaEvent),
     RequestResponse(RequestResponseEvent<ArtifactRequest, ArtifactResponse>),
+    BuildRequestResponse(RequestResponseEvent<BuildRequest, BuildResponse>),
     IdleMetricRequestResponse(RequestResponseEvent<IdleMetricRequest, IdleMetricResponse>),
     BlockUpdateRequestResponse(RequestResponseEvent<BlockUpdateRequest, BlockUpdateResponse>),
 }
@@ -81,6 +84,12 @@ impl From<KademliaEvent> for PyrsiaNetworkEvent {
 impl From<RequestResponseEvent<ArtifactRequest, ArtifactResponse>> for PyrsiaNetworkEvent {
     fn from(event: RequestResponseEvent<ArtifactRequest, ArtifactResponse>) -> Self {
         PyrsiaNetworkEvent::RequestResponse(event)
+    }
+}
+
+impl From<RequestResponseEvent<BuildRequest, BuildResponse>> for PyrsiaNetworkEvent {
+    fn from(event: RequestResponseEvent<BuildRequest, BuildResponse>) -> Self {
+        PyrsiaNetworkEvent::BuildRequestResponse(event)
     }
 }
 

--- a/src/network/build_protocol.rs
+++ b/src/network/build_protocol.rs
@@ -1,0 +1,126 @@
+/*
+   Copyright 2021 JFrog Ltd
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+use crate::artifact_service::model::PackageType;
+use async_trait::async_trait;
+use futures::prelude::*;
+use libp2p::core::upgrade::{read_length_prefixed, write_length_prefixed, ProtocolName};
+use libp2p::request_response::RequestResponseCodec;
+use log::debug;
+use std::io;
+use std::str::FromStr;
+
+#[derive(Debug, Clone)]
+pub struct BuildExchangeProtocol();
+/// The `BuildExchangeCodec` defines the request and response types
+/// for the [`RequestResponse`](crate::RequestResponse) protocol for
+/// exchanging builds. At the moment, the implementation for
+/// encoding/decoding writes all bytes of a single artifact at once.
+#[derive(Clone)]
+pub struct BuildExchangeCodec();
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BuildRequest(pub PackageType, pub String);
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BuildResponse();
+
+impl ProtocolName for BuildExchangeProtocol {
+    fn protocol_name(&self) -> &[u8] {
+        "/build-exchange/1".as_bytes()
+    }
+}
+
+#[async_trait]
+impl RequestResponseCodec for BuildExchangeCodec {
+    type Protocol = BuildExchangeProtocol;
+    type Request = BuildRequest;
+    type Response = BuildResponse;
+
+    async fn read_request<T>(
+        &mut self,
+        _: &BuildExchangeProtocol,
+        io: &mut T,
+    ) -> io::Result<Self::Request>
+    where
+        T: AsyncRead + Unpin + Send,
+    {
+        debug!("Reading BuildRequest...");
+
+        let hash_vec0 = read_length_prefixed(io, 1_000_000).await?;
+        if hash_vec0.is_empty() {
+            return Err(io::ErrorKind::UnexpectedEof.into());
+        }
+
+        let package_type_string = String::from_utf8(hash_vec0).unwrap();
+        let package_type = PackageType::from_str(&package_type_string).unwrap();
+
+        let hash_vec1 = read_length_prefixed(io, 1_000_000).await?;
+        if hash_vec1.is_empty() {
+            return Err(io::ErrorKind::UnexpectedEof.into());
+        }
+
+        let package_specific_id = String::from_utf8(hash_vec1).unwrap();
+        debug!(
+            "Read BuildRequest: {:?}:{}",
+            package_type, package_specific_id
+        );
+
+        Ok(BuildRequest(package_type, package_specific_id))
+    }
+
+    async fn read_response<T>(
+        &mut self,
+        _: &BuildExchangeProtocol,
+        _io: &mut T,
+    ) -> io::Result<Self::Response>
+    where
+        T: AsyncRead + Unpin + Send,
+    {
+        Ok(BuildResponse())
+    }
+
+    async fn write_request<T>(
+        &mut self,
+        _: &BuildExchangeProtocol,
+        io: &mut T,
+        BuildRequest(package_type, package_specific_id): BuildRequest,
+    ) -> io::Result<()>
+    where
+        T: AsyncWrite + Unpin + Send,
+    {
+        debug!(
+            "Write BuildRequest: {:?}: {}",
+            package_type, package_specific_id
+        );
+
+        write_length_prefixed(io, package_type.to_string()).await?;
+        write_length_prefixed(io, package_specific_id).await?;
+        io.close().await?;
+
+        Ok(())
+    }
+
+    async fn write_response<T>(
+        &mut self,
+        _: &BuildExchangeProtocol,
+        _io: &mut T,
+        BuildResponse(): BuildResponse,
+    ) -> io::Result<()>
+    where
+        T: AsyncWrite + Unpin + Send,
+    {
+        Ok(())
+    }
+}

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -21,13 +21,13 @@ use crate::network::artifact_protocol::ArtifactResponse;
 use crate::network::client::command::Command;
 use crate::network::idle_metric_protocol::{IdleMetricResponse, PeerMetrics};
 use crate::node_api::model::cli::Status;
+use anyhow::Error;
 use libp2p::core::{Multiaddr, PeerId};
 use libp2p::request_response::ResponseChannel;
 use log::debug;
 use pyrsia_blockchain_network::structures::block::Block;
 use pyrsia_blockchain_network::structures::header::Ordinal;
 use std::collections::HashSet;
-use anyhow::Error;
 use tokio::sync::{mpsc, oneshot};
 
 /* peer metrics support */

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -27,7 +27,7 @@ use log::debug;
 use pyrsia_blockchain_network::structures::block::Block;
 use pyrsia_blockchain_network::structures::header::Ordinal;
 use std::collections::HashSet;
-use tokio::sync::oneshot::error::RecvError;
+use anyhow::Error;
 use tokio::sync::{mpsc, oneshot};
 
 /* peer metrics support */
@@ -184,7 +184,7 @@ impl Client {
         peer_id: &PeerId,
         package_type: PackageType,
         package_specific_id: String,
-    ) -> Result<String, RecvError> {
+    ) -> anyhow::Result<String> {
         debug!(
             "p2p::Client::request_build {:?}: {:?}: {:?}",
             peer_id, package_type, package_specific_id
@@ -206,13 +206,10 @@ impl Client {
         }
 
         match receiver.await {
-            Ok(_) => {
-                debug!("Receiver of build request ok");
-                Ok(String::from("ok"))
-            }
+            Ok(result) => result,
             Err(e) => {
                 debug!("Receiver of build request error: {:?}", e);
-                Err(e)
+                Err(Error::from(e))
             }
         }
     }

--- a/src/network/client/command.rs
+++ b/src/network/client/command.rs
@@ -14,6 +14,7 @@
    limitations under the License.
 */
 
+use crate::artifact_service::model::PackageType;
 use crate::network::artifact_protocol::ArtifactResponse;
 use crate::network::idle_metric_protocol::{IdleMetricResponse, PeerMetrics};
 use crate::node_api::model::cli::Status;
@@ -58,6 +59,12 @@ pub enum Command {
     ListProviders {
         artifact_id: String,
         sender: oneshot::Sender<HashSet<PeerId>>,
+    },
+    RequestBuild {
+        peer: PeerId,
+        package_type: PackageType,
+        package_specific_id: String,
+        sender: oneshot::Sender<anyhow::Result<()>>,
     },
     RequestArtifact {
         artifact_id: String,

--- a/src/network/client/command.rs
+++ b/src/network/client/command.rs
@@ -64,7 +64,7 @@ pub enum Command {
         peer: PeerId,
         package_type: PackageType,
         package_specific_id: String,
-        sender: oneshot::Sender<anyhow::Result<()>>,
+        sender: oneshot::Sender<anyhow::Result<String>>,
     },
     RequestArtifact {
         artifact_id: String,

--- a/src/network/event_loop.rs
+++ b/src/network/event_loop.rs
@@ -120,13 +120,13 @@ impl PyrsiaEventLoop {
         trace!("Handle AutonatEvent: {:?}", event);
         match event {
             AutonatEvent::InboundProbe(evt) => {
-                debug!("AutonatEvent::InboundProbe {:?}", evt);
+                trace!("AutonatEvent::InboundProbe {:?}", evt);
                 // let peer = evt.Request.ge
                 // let address = evt.get_address();
                 // self.swarm.behaviour_mut().auto_nat.add_server(peer, address);
             }
             AutonatEvent::OutboundProbe(evt) => {
-                debug!("AutonatEvent::OutboundProbe {:?}", evt);
+                trace!("AutonatEvent::OutboundProbe {:?}", evt);
             }
             AutonatEvent::StatusChanged { old, new } => {
                 info!("State changed from {:?} to {:?}", old, new);

--- a/src/network/event_loop.rs
+++ b/src/network/event_loop.rs
@@ -45,7 +45,7 @@ type PendingDialMap = HashMap<PeerId, oneshot::Sender<anyhow::Result<()>>>;
 type PendingListPeersMap = HashMap<QueryId, oneshot::Sender<HashSet<PeerId>>>;
 type PendingStartProvidingMap = HashMap<QueryId, oneshot::Sender<()>>;
 type PendingRequestArtifactMap = HashMap<RequestId, oneshot::Sender<anyhow::Result<Vec<u8>>>>;
-type PendingRequestBuildMap = HashMap<RequestId, oneshot::Sender<anyhow::Result<()>>>;
+type PendingRequestBuildMap = HashMap<RequestId, oneshot::Sender<anyhow::Result<String>>>;
 type PendingRequestIdleMetricMap = HashMap<RequestId, oneshot::Sender<anyhow::Result<PeerMetrics>>>;
 type PendingRequestBlockUpdateMap =
     HashMap<RequestId, oneshot::Sender<anyhow::Result<Option<u64>>>>;
@@ -347,7 +347,7 @@ impl PyrsiaEventLoop {
                     self.pending_request_build
                         .remove(&request_id)
                         .expect("Request to still be pending.")
-                        .send(Ok(()))
+                        .send(Ok(request_id.to_string()))
                         .unwrap_or_else(|e| {
                             error!(
                                 "Handle RequestResponseEvent match arm: {}. Error: {:?}",

--- a/src/network/p2p.rs
+++ b/src/network/p2p.rs
@@ -23,6 +23,7 @@ use crate::network::idle_metric_protocol::{IdleMetricExchangeCodec, IdleMetricEx
 use crate::util::keypair_util;
 use crate::util::keypair_util::KEYPAIR_FILENAME;
 
+use crate::network::build_protocol::{BuildExchangeCodec, BuildExchangeProtocol};
 use libp2p::kad::record::store::{MemoryStore, MemoryStoreConfig};
 use libp2p::request_response::{ProtocolSupport, RequestResponse};
 use libp2p::swarm::{Swarm, SwarmBuilder};
@@ -177,6 +178,11 @@ fn create_swarm(
                 request_response: RequestResponse::new(
                     ArtifactExchangeCodec(),
                     iter::once((ArtifactExchangeProtocol(), ProtocolSupport::Full)),
+                    Default::default(),
+                ),
+                build_request_response: RequestResponse::new(
+                    BuildExchangeCodec(),
+                    iter::once((BuildExchangeProtocol(), ProtocolSupport::Full)),
                     Default::default(),
                 ),
                 idle_metric_request_response: RequestResponse::new(

--- a/src/node_api/handlers/swarm.rs
+++ b/src/node_api/handlers/swarm.rs
@@ -15,7 +15,6 @@
 */
 
 use crate::artifact_service::model::PackageType;
-use crate::build_service::event::BuildEventClient;
 use crate::docker::error_util::RegistryError;
 use crate::network::client::Client;
 use crate::node_api::model::cli::{
@@ -23,15 +22,16 @@ use crate::node_api::model::cli::{
 };
 use crate::transparency_log::log::TransparencyLogService;
 
+use crate::artifact_service::service::ArtifactService;
 use log::debug;
 use warp::{http::StatusCode, Rejection, Reply};
 
 pub async fn handle_build_docker(
     request_docker_build: RequestDockerBuild,
-    build_event_client: BuildEventClient,
+    artifact_service: ArtifactService,
 ) -> Result<impl Reply, Rejection> {
-    let build_id = build_event_client
-        .start_build(PackageType::Docker, request_docker_build.image)
+    let build_id = artifact_service
+        .request_build(PackageType::Docker, request_docker_build.image)
         .await
         .map_err(RegistryError::from)?;
 
@@ -45,10 +45,10 @@ pub async fn handle_build_docker(
 
 pub async fn handle_build_maven(
     request_maven_build: RequestMavenBuild,
-    build_event_client: BuildEventClient,
+    artifact_service: ArtifactService,
 ) -> Result<impl Reply, Rejection> {
-    let build_id = build_event_client
-        .start_build(PackageType::Maven2, request_maven_build.gav)
+    let build_id = artifact_service
+        .request_build(PackageType::Maven2, request_maven_build.gav)
         .await
         .map_err(RegistryError::from)?;
 

--- a/src/node_api/routes.rs
+++ b/src/node_api/routes.rs
@@ -16,18 +16,18 @@
 
 use super::handlers::swarm::*;
 use super::model::cli::{RequestDockerBuild, RequestMavenBuild};
-use crate::build_service::event::BuildEventClient;
+use crate::artifact_service::service::ArtifactService;
 use crate::network::client::Client;
 use crate::node_api::model::cli::{RequestDockerLog, RequestMavenLog};
 use crate::transparency_log::log::TransparencyLogService;
 use warp::Filter;
 
 pub fn make_node_routes(
-    build_event_client: BuildEventClient,
+    artifact_service: ArtifactService,
     p2p_client: Client,
     transparency_log_service: TransparencyLogService,
 ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
-    let build_event_client_filter = warp::any().map(move || build_event_client.clone());
+    let artifact_service_filter = warp::any().map(move || artifact_service.clone());
     let p2p_client_filter = warp::any().map(move || p2p_client.clone());
     let transparency_log_service_filter = warp::any().map(move || transparency_log_service.clone());
 
@@ -36,7 +36,7 @@ pub fn make_node_routes(
         .and(warp::path::end())
         .and(warp::body::content_length_limit(1024 * 8))
         .and(warp::body::json::<RequestDockerBuild>())
-        .and(build_event_client_filter.clone())
+        .and(artifact_service_filter.clone())
         .and_then(handle_build_docker);
 
     let build_maven = warp::path!("build" / "maven")
@@ -44,7 +44,7 @@ pub fn make_node_routes(
         .and(warp::path::end())
         .and(warp::body::content_length_limit(1024 * 8))
         .and(warp::body::json::<RequestMavenBuild>())
-        .and(build_event_client_filter)
+        .and(artifact_service_filter)
         .and_then(handle_build_maven);
 
     let peers = warp::path!("peers")
@@ -123,13 +123,23 @@ mod tests {
         BlockchainService::new(ed25519_keypair, p2p_client)
     }
 
-    fn create_build_event_client() -> (mpsc::Receiver<BuildEvent>, BuildEventClient) {
+    fn create_artifact_service<P: AsRef<Path>>(
+        artifact_path: P,
+        transparency_log_service: TransparencyLogService,
+        p2p_client: Client,
+    ) -> (mpsc::Receiver<BuildEvent>, ArtifactService) {
         let (build_event_sender, build_event_receiver) = mpsc::channel(1);
+        let build_event_client = BuildEventClient::new(build_event_sender);
 
-        (
-            build_event_receiver,
-            BuildEventClient::new(build_event_sender),
+        let artifact_service = ArtifactService::new(
+            &artifact_path,
+            transparency_log_service,
+            build_event_client,
+            p2p_client,
         )
+        .expect("Creating ArtifactService failed");
+
+        (build_event_receiver, artifact_service)
     }
 
     fn create_transparency_log_service<P: AsRef<Path>>(
@@ -149,9 +159,14 @@ mod tests {
 
         let local_keypair = Keypair::generate_ed25519();
         let (_command_receiver, p2p_client) = create_p2p_client(&local_keypair);
-        let (mut build_event_receiver, build_event_client) = create_build_event_client();
         let transparency_log_service =
             create_transparency_log_service(&tmp_dir, local_keypair.clone(), p2p_client.clone());
+
+        let (mut build_event_receiver, artifact_service) = create_artifact_service(
+            &tmp_dir,
+            transparency_log_service.clone(),
+            p2p_client.clone(),
+        );
 
         transparency_log_service
             .add_authorized_node(local_keypair.public().to_peer_id())
@@ -169,7 +184,7 @@ mod tests {
             }
         });
 
-        let filter = make_node_routes(build_event_client, p2p_client, transparency_log_service);
+        let filter = make_node_routes(artifact_service, p2p_client, transparency_log_service);
         let request = RequestDockerBuild {
             image: "alpine:3.15.2".to_owned(),
         };
@@ -194,9 +209,14 @@ mod tests {
 
         let local_keypair = Keypair::generate_ed25519();
         let (_command_receiver, p2p_client) = create_p2p_client(&local_keypair);
-        let (mut build_event_receiver, build_event_client) = create_build_event_client();
         let transparency_log_service =
             create_transparency_log_service(&tmp_dir, local_keypair.clone(), p2p_client.clone());
+
+        let (mut build_event_receiver, artifact_service) = create_artifact_service(
+            &tmp_dir,
+            transparency_log_service.clone(),
+            p2p_client.clone(),
+        );
 
         transparency_log_service
             .add_authorized_node(local_keypair.public().to_peer_id())
@@ -214,7 +234,7 @@ mod tests {
             }
         });
 
-        let filter = make_node_routes(build_event_client, p2p_client, transparency_log_service);
+        let filter = make_node_routes(artifact_service, p2p_client, transparency_log_service);
         let request = RequestMavenBuild {
             gav: "commons-codec:commons-codec:1.15".to_owned(),
         };
@@ -239,9 +259,13 @@ mod tests {
 
         let local_keypair = Keypair::generate_ed25519();
         let (mut command_receiver, p2p_client) = create_p2p_client(&local_keypair);
-        let (_build_event_receiver, build_event_client) = create_build_event_client();
         let transparency_log_service =
             create_transparency_log_service(&tmp_dir, local_keypair, p2p_client.clone());
+        let (_build_event_receiver, artifact_service) = create_artifact_service(
+            &tmp_dir,
+            transparency_log_service.clone(),
+            p2p_client.clone(),
+        );
 
         tokio::spawn(async move {
             loop {
@@ -257,7 +281,7 @@ mod tests {
         });
 
         let filter = make_node_routes(
-            build_event_client,
+            artifact_service,
             p2p_client.clone(),
             transparency_log_service,
         );
@@ -278,9 +302,13 @@ mod tests {
 
         let local_keypair = Keypair::generate_ed25519();
         let (mut command_receiver, p2p_client) = create_p2p_client(&local_keypair);
-        let (_build_event_receiver, build_event_client) = create_build_event_client();
         let transparency_log_service =
             create_transparency_log_service(&tmp_dir, local_keypair, p2p_client.clone());
+        let (_build_event_receiver, artifact_service) = create_artifact_service(
+            &tmp_dir,
+            transparency_log_service.clone(),
+            p2p_client.clone(),
+        );
 
         tokio::spawn(async move {
             loop {
@@ -305,7 +333,7 @@ mod tests {
         });
 
         let filter = make_node_routes(
-            build_event_client,
+            artifact_service,
             p2p_client.clone(),
             transparency_log_service,
         );

--- a/src/node_api/routes.rs
+++ b/src/node_api/routes.rs
@@ -147,7 +147,12 @@ mod tests {
         let local_keypair = Keypair::generate_ed25519();
         let (_command_receiver, p2p_client) = create_p2p_client(&local_keypair);
         let (mut build_event_receiver, artifact_service) =
-            create_artifact_service(&tmp_dir, local_keypair, p2p_client);
+            create_artifact_service(&tmp_dir, local_keypair.clone(), p2p_client);
+
+        artifact_service
+            .transparency_log_service
+            .add_authorized_node(local_keypair.public().to_peer_id())
+            .expect("Error adding authorized node");
 
         let build_id = uuid::Uuid::new_v4();
         tokio::spawn(async move {
@@ -187,7 +192,12 @@ mod tests {
         let local_keypair = Keypair::generate_ed25519();
         let (_command_receiver, p2p_client) = create_p2p_client(&local_keypair);
         let (mut build_event_receiver, artifact_service) =
-            create_artifact_service(&tmp_dir, local_keypair, p2p_client);
+            create_artifact_service(&tmp_dir, local_keypair.clone(), p2p_client);
+
+        artifact_service
+            .transparency_log_service
+            .add_authorized_node(local_keypair.public().to_peer_id())
+            .expect("Error adding authorized node");
 
         let build_id = uuid::Uuid::new_v4();
         tokio::spawn(async move {

--- a/src/transparency_log/log.rs
+++ b/src/transparency_log/log.rs
@@ -102,7 +102,7 @@ pub struct TransparencyLog {
     source_id: String,
     timestamp: u64,
     pub operation: Operation,
-    node_id: String,
+    pub node_id: String,
     node_public_key: String,
 }
 
@@ -142,7 +142,28 @@ impl TransparencyLogService {
     }
 
     /// Add a new authorized node to the p2p network.
-    pub fn add_authorized_node(&self, _peer_id: PeerId) -> Result<(), TransparencyLogError> {
+    pub fn add_authorized_node(&self, peer_id: PeerId) -> Result<(), TransparencyLogError> {
+        let transparency_log = TransparencyLog {
+            id: Uuid::new_v4().to_string(),
+            package_type: None,
+            package_specific_id: String::from(""),
+            num_artifacts: 0,
+            package_specific_artifact_id: String::from(""),
+            artifact_hash: String::from(""),
+            source_hash: String::from(""),
+            artifact_id: String::from(""),
+            source_id: String::from(""),
+            timestamp: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+            operation: Operation::AddNode,
+            node_id: peer_id.to_string(),
+            node_public_key: Uuid::new_v4().to_string(),
+        };
+
+        self.write_transparency_log(&transparency_log)?;
+
         Ok(())
     }
 

--- a/src/transparency_log/log.rs
+++ b/src/transparency_log/log.rs
@@ -446,6 +446,7 @@ impl TransparencyLogService {
 mod tests {
     use super::*;
     use crate::util::test_util;
+    use libp2p::identity::Keypair;
 
     #[test]
     fn create_transparency_log() {
@@ -823,6 +824,42 @@ mod tests {
         let result_read = log.get_authorized_nodes();
         assert!(result_read.is_ok());
         assert_eq!(result_read.unwrap().len(), 0);
+
+        test_util::tests::teardown(tmp_dir);
+    }
+
+    #[test]
+    fn test_add_authorized_nodes() {
+        let tmp_dir = test_util::tests::setup();
+
+        let log = create_transparency_log_service(&tmp_dir);
+
+        let peer_id = Keypair::generate_ed25519().public().to_peer_id();
+
+        let transparency_log = TransparencyLog {
+            id: String::from("id"),
+            package_type: None,
+            package_specific_id: String::from(""),
+            num_artifacts: 0,
+            package_specific_artifact_id: String::from(""),
+            artifact_hash: String::from(""),
+            source_hash: String::from(""),
+            artifact_id: String::from(""),
+            source_id: String::from(""),
+            timestamp: 10000000,
+            operation: Operation::AddNode,
+            node_id: peer_id.clone().to_string(),
+            node_public_key: Uuid::new_v4().to_string(),
+        };
+
+        let result_add = log.add_authorized_node(peer_id);
+        assert!(result_add.is_ok());
+
+        let result_read = log.get_authorized_nodes();
+        assert!(result_read.is_ok());
+        let vec = result_read.unwrap();
+        assert_eq!(vec.len(), 1);
+        assert_eq!(vec.get(0).unwrap().node_id, transparency_log.node_id);
 
         test_util::tests::teardown(tmp_dir);
     }


### PR DESCRIPTION
<!--

Thank you for participating with our effort to build a more secure software supply chain.
Before submitting your Pull Request, please go over our check list.

-->

## Description

<!--

Try to fill in the following to help the reviewers dive into the pull request.
Explain the context and what changed.

-->

Fixes pyrsia/pyrsia#1004

This PR allows triggering a build (docker/maven) only on authorized nodes. If the node is already authorized, the build runs locally as it was before, else it sends a request to the P2P network to start the build on one of the existing authorized nodes, if any.

Important: Currently there is no built-in system that provides authorized nodes when pyrsia starts, so these changes won't work out of the box. In fact, both local and P2P builds will fail.

As a manual workaround for anyone that wants to test these changes, once the nodes A, B are created following the [Docker](https://github.com/pyrsia/pyrsia/blob/main/docs/tutorials/build_from_source_docker.md) tutorial or the [Maven](https://github.com/pyrsia/pyrsia/blob/main/docs/tutorials/build_from_source_maven.md) tutorial, the transparency log database can be modified to include the peerId of the nodeA:


- nodeA

```
mkdir nodeA && cp target/debug/pyrsia_node nodeA && cd nodeA
RUST_LOG=pyrsia=debug DEV_MODE=on ./pyrsia_node --pipeline-service-endpoint http://localhost:8080/ -p 7889 --listen-only true
```

- nodeB

```
mkdir nodeB && cp target/debug/pyrsia_node nodeB && cd nodeB
RUST_LOG=pyrsia=debug DEV_MODE=on ./pyrsia_node -H 0.0.0.0 --peer /ip4/127.0.0.1/tcp/XXXXX/p2p/YYYYYYYY // from nodeA
```

- pyrsia

```
./pyrsia config -e [7889]
./pyrsia inspect-log docker --image alpine:3.16 // create transparency log on nodeA
./pyrsia config -e [7888]
./pyrsia inspect-log docker --image alpine:3.16 // create transparency log on nodeB
```
Now process this query for the Transparency logs of both nodeA and nodeB:

```
INSERT INTO TRANSPARENCYLOG (id, package_specific_id, num_artifacts, package_specific_artifact_id, artifact_hash, source_hash, artifact_id, source_id, timestamp, operation, node_id, node_public_key) VALUES ('1', '', '0', '', '', '', '', '', '1000000', 'AddNode', 'YYYYYYYY', '');
```

- pipeline

```
cargo run
```

- pyrsia

```
./pyrsia build docker --image alpine:3.16
// ./pyrsia build maven --gav commons-codec:commons-codec:1.15
```

## Screenshots (optional)

## PR Checklist

<!-- Make certain you've done the following. -->

- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/get_involved/good_pr.md)
- [x] I've included a good title and brief description along with how to review them.
- [x] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).

### Code Contributions

<!--

This section applies to code modifications, you may remove it otherwise.

Make sure your Pull Request will pass the CI/CD pipeline.
For a complete list of steps, check out the [developer workflow](https://github.com/pyrsia/pyrsia/blob/main/docs/get_involved/dev_workflow.md)!

-->

- [x] I've built the code `cargo build --all-targets` successfully.
- [x] I've run the unit tests `cargo test --workspace` and everything passes.
- [x] I've made sure my rust toolchain is current `rustup update`.
