### PR TITLE
Fix logic for first boot node and ca-certificates error in docker build

### DIFF
--- a/installers/docker/AptGet.Dockerfile
+++ b/installers/docker/AptGet.Dockerfile
@@ -8,7 +8,7 @@ EXPOSE 44000
 ENV RUST_LOG=info
 
 RUN apt-get update; \
-    apt-get -y install wget gnupg2 jq curl; \
+    apt-get -y install ca-certificates wget gnupg2 jq curl; \
     wget -O - https://pyrsia.io/install.sh | sh; 
 
 # Need to run an entrypoint script that will determine if the docker container

--- a/installers/docker/node-entrypoint.sh
+++ b/installers/docker/node-entrypoint.sh
@@ -12,12 +12,15 @@ if [ -f /var/run/secrets/kubernetes.io/serviceaccount/namespace ]; then
     export PYRSIA_EXTERNAL_IP=$(curl -s --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -X GET ${APISERVER}/api/v1/namespaces/${NAMESPACE}/services/${PODNAME} | jq -r ".status.loadBalancer.ingress[0].ip")
     echo "PYRSIA_EXTERNAL_IP=$PYRSIA_EXTERNAL_IP"
 
-    # detemine if I am node-0 if so be the primary boot node
-    if [ "$(hostname | rev | cut -c -2 | rev)" = "-0" ]; then
+    # detemine if I am pyrsia-node-0.pyrsia.link (first boot node ever) if so be the primary boot node
+    # need to use wget since nslookup, dig and ping are not installed
+    if wget --timeout=2 -v pyrsia-node-0.pyrsia.link 2>&1 | grep Connecting | grep -q "${PYRSIA_EXTERNAL_IP}" ; then  
         /usr/bin/pyrsia_node $* --listen-only true  
     else
-        /usr/bin/pyrsia_node $* 
+        # I am not pyrsia-node-0.pyrsia.link so use boot.pyrsia.link for boot address and connect to it
+        /usr/bin/pyrsia_node $*
     fi
 else
-    /usr/bin/pyrsia_node $* 
+    # not running under k8s so just startup in default mode
+    /usr/bin/pyrsia_node $*
 fi

--- a/installers/helm/pyrsia-node/templates/deployment.yaml
+++ b/installers/helm/pyrsia-node/templates/deployment.yaml
@@ -40,10 +40,19 @@ spec:
               mountPath: "/usr/local/var/pyrsia"
             - name: pyrsia-p2p-keys
               mountPath: /usr/local/var/pyrsia-p2p-keys
-      volumes:
-        - name: pyrsia-storage
-          persistentVolumeClaim:
-            claimName: pyrsia-storage-pvc
-        - name: pyrsia-p2p-keys
-          persistentVolumeClaim:
-            claimName: pyrsia-p2p-keys-pvc                 
+  volumeClaimTemplates:
+  - metadata:
+      name: pyrsia-storage
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 1500Gi
+  - metadata:
+      name: pyrsia-p2p-keys
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 10Gi
+      storageClassName: pyrsia-csi              

--- a/installers/helm/pyrsia-node/templates/storage.yaml
+++ b/installers/helm/pyrsia-node/templates/storage.yaml
@@ -22,24 +22,3 @@ spec:
       failure-domain.beta.kubernetes.io/zone: us-phoenix-1
 {{- end }}
 ---
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: pyrsia-p2p-keys-pvc
-spec:
-  storageClassName: pyrsia-csi
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 50Gi
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: pyrsia-storage-pvc
-spec:
-  accessModes: ["ReadWriteOnce"]
-  resources:
-    requests:
-      storage: 1500Gi

--- a/installers/helm/pyrsia-node/values.yaml
+++ b/installers/helm/pyrsia-node/values.yaml
@@ -2,8 +2,8 @@
 replicaCount: 3
 
 image:
-  repository: pyrsiaoss/pyrsia-node
-  tag: 0.1.0-2071
+  repository: sbtaylor15/pyrsia-node
+  tag: 0.1.0-fix
   pullPolicy: Always
 
 p2pkeys:

--- a/installers/helm/pyrsia-node/values.yaml
+++ b/installers/helm/pyrsia-node/values.yaml
@@ -7,5 +7,6 @@ image:
   pullPolicy: Always
 
 p2pkeys:
+  kms_key_id: ""
 
 k8s_provider: gke # "gke, oke, aks, eks"

--- a/installers/helm/pyrsia-node/values.yaml
+++ b/installers/helm/pyrsia-node/values.yaml
@@ -2,11 +2,10 @@
 replicaCount: 3
 
 image:
-  repository: sbtaylor15/pyrsia-node
-  tag: 0.1.0-fix
+  repository: pyrsiaoss/pyrsia-node
+  tag: 0.1.0-2071
   pullPolicy: Always
 
 p2pkeys:
-  kms_key_id: ""
 
 k8s_provider: gke # "gke, oke, aks, eks"


### PR DESCRIPTION
<!--

Thank you for participating with our effort to build a more secure software supply chain.
Before submitting your Pull Request, please go over our check list.

-->

## Description

Use VolumeClaimTemplates instead of PersistentVolumeClaims in order to have a unique volume to store the artifacts and key pairs.  This prevents nodes from starting up with the same peerid. 

Also added ca-certificates package for the `apt-get install pyrsia` to work without root certificate errors which prevents installing pyrsia-node. 

<!--

Try to fill in the following to help the reviewers dive into the pull request.
Explain the context and what changed.

-->


## Screenshots (optional)

## PR Checklist

<!-- Make certain you've done the following. -->

- [X] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [X] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/get_involved/good_pr.md)
- [X] I've included a good title and brief description along with how to review them.
- [X] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).

### Code Contributions

<!--

This section applies to code modifications, you may remove it otherwise.

Make sure your Pull Request will pass the CI/CD pipeline.
For a complete list of steps, check out the [developer workflow](https://github.com/pyrsia/pyrsia/blob/main/docs/get_involved/dev_workflow.md)!

-->

- [X] I've built the code `cargo build --all-targets` successfully.
- [X] I've run the unit tests `cargo test --workspace` and everything passes.
- [X] I've made sure my rust toolchain is current `rustup update`.
