### PR TITLE
Only add public addresses into DHT

### DIFF
--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -129,12 +129,7 @@ impl Client {
     /// List the peers that this node is connected to.
     pub async fn list_peers(&mut self) -> anyhow::Result<HashSet<PeerId>> {
         let (sender, receiver) = oneshot::channel();
-        self.sender
-            .send(Command::ListPeers {
-                peer_id: self.local_peer_id,
-                sender,
-            })
-            .await?;
+        self.sender.send(Command::ListPeers { sender }).await?;
         Ok(receiver.await?)
     }
 
@@ -393,8 +388,7 @@ mod tests {
 
         tokio::select! {
             command = receiver.recv() => match command {
-                Some(Command::ListPeers { peer_id, sender }) => {
-                    assert_eq!(peer_id, local_peer_id);
+                Some(Command::ListPeers { sender }) => {
                     let _ = sender.send(Default::default());
                 },
                 _ => panic!("Command must match Command::ListPeers")

--- a/src/network/client/command.rs
+++ b/src/network/client/command.rs
@@ -44,7 +44,6 @@ pub enum Command {
         sender: oneshot::Sender<anyhow::Result<()>>,
     },
     ListPeers {
-        peer_id: PeerId,
         sender: oneshot::Sender<HashSet<PeerId>>,
     },
     Status {

--- a/src/network/event_loop.rs
+++ b/src/network/event_loop.rs
@@ -741,42 +741,6 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_dial_discovers_both_nodes() {
-        pretty_env_logger::init_timed();
-
-        let (mut p2p_client_1, event_loop_1) = create_test_swarm();
-        let (mut p2p_client_2, event_loop_2) = create_test_swarm();
-
-        tokio::spawn(event_loop_1.run());
-        tokio::spawn(event_loop_2.run());
-
-        p2p_client_1
-            .listen(&"/ip4/127.0.0.1/tcp/44130".parse().unwrap())
-            .await
-            .unwrap();
-        p2p_client_2
-            .listen(&"/ip4/127.0.0.1/tcp/44131".parse().unwrap())
-            .await
-            .unwrap();
-
-        let result = p2p_client_1
-            .dial(
-                &p2p_client_2.local_peer_id,
-                &"/ip4/127.0.0.1/tcp/44131".parse().unwrap(),
-            )
-            .await;
-        assert!(result.is_ok());
-
-        // wait a few seconds for identify negotiation to finish
-        tokio::time::sleep(Duration::from_millis(5000)).await;
-
-        let peers_in_client_1 = p2p_client_1.list_peers().await.unwrap();
-        let peers_in_client_2 = p2p_client_2.list_peers().await.unwrap();
-        assert!(peers_in_client_1.contains(&p2p_client_2.local_peer_id));
-        assert!(peers_in_client_2.contains(&p2p_client_1.local_peer_id));
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
     async fn test_dial_with_invalid_peer_id() {
         let (mut p2p_client_1, event_loop_1) = create_test_swarm();
         let (p2p_client_2, _) = create_test_swarm();


### PR DESCRIPTION
## Description

Fixes #1084

This PR changes the behavior of adding addresses to the Kademlia DHT routing table.

Previously, we waited for an Identify event from an external node and then used the listener addresses from the event and add them to the Kademlia DHT. This gave issues when the addresses are not reachable by the other nodes, causing the Kademlia queries to take a very long time or even time out.

Instead of these Identify events, we now wait for an update in the NAT status as reported by the autonat behavior. If the status changes to NatStatus::Public, the associated public address is added to the Kademlia DHT routing table.

I've also changed the way that a list of peers is retrieved. Instead of querying the Kademlia DHT for a list of known peers, we use the list of nodes that are currently connected to the swarm. Since the autonat behavior is probing the boot node frequently enough, the connection idle timeout will never be reached, hence the node will continously be connected to the boot node.

## PR Checklist

<!-- Make certain you've done the following. -->

- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/get_involved/good_pr.md)
- [x] I've included a good title and brief description along with how to review them.
- [x] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).

### Code Contributions

<!--

This section applies to code modifications, you may remove it otherwise.

Make sure your Pull Request will pass the CI/CD pipeline.
For a complete list of steps, check out the [developer workflow](https://github.com/pyrsia/pyrsia/blob/main/docs/get_involved/dev_workflow.md)!

-->

- [x] I've built the code `cargo build --all-targets` successfully.
- [x] I've run the unit tests `cargo test --workspace` and everything passes.
- [x] I've made sure my rust toolchain is current `rustup update`.
