### PR TITLE
Fix docker build docs - mention jq as prerequisite

### DIFF
--- a/docs/tutorials/build_from_source_docker.md
+++ b/docs/tutorials/build_from_source_docker.md
@@ -124,7 +124,7 @@ The most important features of the build pipeline are:
 The current build pipeline prototype supports Maven and Docker builds.
 
 Download or clone the [prototype repo](https://github.com/tiainen/pyrsia_build_pipeline_prototype)
-and run as follows:
+and run as follows (`jq` must be installed locally before):
 
 ```sh
 cd pyrsia_build_pipeline_prototype


### PR DESCRIPTION
## jq is required in docker pipeline shell script

Fixes pyrsia/pyrsia/docs#

This PR clarifies documentation -   jq is required for prototype docker build pipeline.


## PR Checklist

<!-- Make certain you've done the following. -->

- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/get_involved/good_pr.md)
- [x] I've included a good title and brief description along with how to review them.
- [] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).


