### PR TITLE
allow authorize node request from the CLI #1083

### DIFF
--- a/pyrsia_cli/src/cli/handlers.rs
+++ b/pyrsia_cli/src/cli/handlers.rs
@@ -18,7 +18,7 @@ use lazy_static::lazy_static;
 use pyrsia::cli_commands::config;
 use pyrsia::cli_commands::node;
 use pyrsia::node_api::model::cli::{
-    RequestDockerBuild, RequestDockerLog, RequestMavenBuild, RequestMavenLog,
+    RequestAddNode, RequestDockerBuild, RequestDockerLog, RequestMavenBuild, RequestMavenLog,
 };
 use regex::Regex;
 use std::collections::HashSet;
@@ -92,6 +92,17 @@ fn handle_request_build_result(build_result: Result<String, reqwest::Error>) {
     }
 }
 
+fn handle_request_authorize(authorize_result: Result<String, reqwest::Error>) {
+    match authorize_result {
+        Ok(_auth_id) => {
+            println!("Authorize request successfully handled.",);
+        }
+        Err(error) => {
+            println!("Authorize request failed with error: {}", error);
+        }
+    }
+}
+
 pub async fn node_ping() {
     let result = node::ping().await;
     match result {
@@ -132,6 +143,14 @@ pub async fn node_list() {
             println!("Error: {}. {}", error, CONF_REMINDER_MESSAGE);
         }
     }
+}
+
+pub async fn request_authorize(peer_id: &str) {
+    let build_result = node::request_authorize(RequestAddNode {
+        peer_id: peer_id.to_owned(),
+    })
+    .await;
+    handle_request_authorize(build_result);
 }
 
 pub async fn inspect_docker_transparency_log(image: &str) {

--- a/pyrsia_cli/src/cli/handlers.rs
+++ b/pyrsia_cli/src/cli/handlers.rs
@@ -18,7 +18,8 @@ use lazy_static::lazy_static;
 use pyrsia::cli_commands::config;
 use pyrsia::cli_commands::node;
 use pyrsia::node_api::model::cli::{
-    RequestAddNode, RequestDockerBuild, RequestDockerLog, RequestMavenBuild, RequestMavenLog,
+    RequestAddAuthorizedNode, RequestDockerBuild, RequestDockerLog, RequestMavenBuild,
+    RequestMavenLog,
 };
 use regex::Regex;
 use std::collections::HashSet;
@@ -62,6 +63,17 @@ pub fn config_show() {
     };
 }
 
+pub async fn authorize(peer_id: &str) {
+    match node::add_authorized_node(RequestAddAuthorizedNode {
+        peer_id: peer_id.to_owned(),
+    })
+    .await
+    {
+        Ok(_) => println!("Authorize request successfully handled."),
+        Err(error) => println!("Authorize request failed with error: {}", error),
+    };
+}
+
 pub async fn request_docker_build(image: &str) {
     let build_result = node::request_docker_build(RequestDockerBuild {
         image: image.to_owned(),
@@ -88,17 +100,6 @@ fn handle_request_build_result(build_result: Result<String, reqwest::Error>) {
         }
         Err(error) => {
             println!("Build request failed with error: {}", error);
-        }
-    }
-}
-
-fn handle_request_authorize(authorize_result: Result<String, reqwest::Error>) {
-    match authorize_result {
-        Ok(_auth_id) => {
-            println!("Authorize request successfully handled.",);
-        }
-        Err(error) => {
-            println!("Authorize request failed with error: {}", error);
         }
     }
 }
@@ -145,14 +146,6 @@ pub async fn node_list() {
     }
 }
 
-pub async fn request_authorize(peer_id: &str) {
-    let build_result = node::request_authorize(RequestAddNode {
-        peer_id: peer_id.to_owned(),
-    })
-    .await;
-    handle_request_authorize(build_result);
-}
-
 pub async fn inspect_docker_transparency_log(image: &str) {
     let result = node::inspect_docker_transparency_log(RequestDockerLog {
         image: image.to_owned(),
@@ -184,23 +177,17 @@ pub async fn inspect_maven_transparency_log(gav: &str) {
 }
 
 /// Read user input interactively until the validation passed
-fn read_interactive_input<'a>(
-    cli_prompt: &str,
-    validation_func: &'a dyn Fn(&str) -> bool,
-) -> String {
+fn read_interactive_input(cli_prompt: &str, validation_func: &dyn Fn(&str) -> bool) -> String {
     loop {
         println!("{}", cli_prompt);
         let mut buffer = String::new();
-        match io::stdin().lock().read_line(&mut buffer) {
-            Ok(bytes_read) => {
-                if bytes_read > 0 {
-                    let input = buffer.lines().next().unwrap();
-                    if validation_func(input.clone()) {
-                        break input.to_string();
-                    }
+        if let Ok(bytes_read) = io::stdin().lock().read_line(&mut buffer) {
+            if bytes_read > 0 {
+                let input = buffer.lines().next().unwrap();
+                if validation_func(input) {
+                    break input.to_string();
                 }
             }
-            Err(_) => {}
         }
     }
 }
@@ -221,20 +208,14 @@ fn valid_host(input: &str) -> bool {
 
     /// Returns true if input is a valid IPv4 address, otherwise false
     fn valid_ipv4_address(input: &str) -> bool {
-        match input.parse::<Ipv4Addr>() {
-            Ok(_) => true,
-            Err(_) => false,
-        }
+        input.parse::<Ipv4Addr>().is_ok()
     }
 
     valid_ipv4_address(input) || valid_hostname(input)
 }
 
 fn valid_port(input: &str) -> bool {
-    match input.parse::<u16>() {
-        Ok(_) => true,
-        Err(_) => false,
-    }
+    input.parse::<u16>().is_ok()
 }
 
 fn valid_disk_space(input: &str) -> bool {
@@ -266,7 +247,7 @@ mod tests {
     #[test]
     fn test_valid_host() {
         let valid_hosts = vec!["pyrsia.io", "localhost", "10.10.10.255"];
-        assert!(valid_hosts.into_iter().all(|x| valid_host(x)));
+        assert!(valid_hosts.into_iter().all(valid_host));
     }
 
     #[test]
@@ -276,34 +257,30 @@ mod tests {
             "@localhost",
             "%*%*%*%*NO_SENSE_AS_HOST@#$*@#$*@#$*",
         ];
-        assert!(!invalid_hosts.into_iter().any(|x| valid_host(x)));
+        assert!(!invalid_hosts.into_iter().any(valid_host));
     }
 
     #[test]
     fn test_valid_port() {
         let valid_ports = vec!["0", "8988", "65535"];
-        assert!(valid_ports.into_iter().all(|x| valid_port(x)));
+        assert!(valid_ports.into_iter().all(valid_port));
     }
 
     #[test]
     fn test_invalid_port() {
         let invalid_ports = vec!["-1", "65536"];
-        assert!(!invalid_ports.into_iter().any(|x| valid_port(x)));
+        assert!(!invalid_ports.into_iter().any(valid_port));
     }
 
     #[test]
     fn test_valid_disk_space() {
         let valid_disk_space_list = vec!["100 GB", "1 GB", "4096 GB"];
-        assert!(valid_disk_space_list
-            .into_iter()
-            .all(|x| valid_disk_space(x)));
+        assert!(valid_disk_space_list.into_iter().all(valid_disk_space));
     }
 
     #[test]
     fn test_invalid_disk_space() {
         let invalid_disk_space_list = vec!["0 GB", "4097 GB", "100GB", "100gb"];
-        assert!(!invalid_disk_space_list
-            .into_iter()
-            .any(|x| valid_disk_space(x)));
+        assert!(!invalid_disk_space_list.into_iter().any(valid_disk_space));
     }
 }

--- a/pyrsia_cli/src/cli/handlers.rs
+++ b/pyrsia_cli/src/cli/handlers.rs
@@ -69,7 +69,7 @@ pub async fn authorize(peer_id: &str) {
     })
     .await
     {
-        Ok(_) => println!("Authorize request successfully handled."),
+        Ok(()) => println!("Authorize request successfully handled."),
         Err(error) => println!("Authorize request failed with error: {}", error),
     };
 }

--- a/pyrsia_cli/src/cli/parser.rs
+++ b/pyrsia_cli/src/cli/parser.rs
@@ -25,15 +25,11 @@ pub fn cli_parser() -> ArgMatches {
         .propagate_version(false)
         // Config subcommand
         .subcommands(vec![
-            Command::new("config")
-                .short_flag('c')
-                .about("Pyrsia config commands")
+            Command::new("authorize")
+                .about("Add an authorized node")
                 .arg_required_else_help(true)
                 .args(&[
-                    arg!(-a --add      "Adds a node configuration"),
-                    arg!(-e --edit     "Edits a node configuration"),
-                    arg!(-r --remove   "Removes the stored node configuration").visible_alias("rm"),
-                    arg!(-s --show     "Shows the stored node configuration"),
+                    arg!(-p --peer <PEER_ID>      "Peer ID of the node to authorize"),
                 ]),
             Command::new("build")
                 .short_flag('b')
@@ -53,36 +49,40 @@ pub fn cli_parser() -> ArgMatches {
                             arg!(--gav <GAV> "The maven GAV (e.g. org.myorg:my-artifact:1.1.0)"),
                         ]),
                 ]),
-            Command::new("list")
-                .short_flag('l')
-                .about("Shows list of connected Peers"),
-            Command::new("ping").about("Pings configured pyrsia node"),
-            Command::new("status")
-                .short_flag('s')
-                .about("Shows node information"),
+            Command::new("config")
+                .short_flag('c')
+                .about("Configure Pyrsia")
+                .arg_required_else_help(true)
+                .args(&[
+                    arg!(-a --add      "Adds a node configuration"),
+                    arg!(-e --edit     "Edits a node configuration"),
+                    arg!(-r --remove   "Removes the stored node configuration").visible_alias("rm"),
+                    arg!(-s --show     "Shows the stored node configuration"),
+                ]),
             Command::new("inspect-log")
-                .about("Shows transparency logs")
+                .about("Show transparency logs")
                 .setting(AppSettings::SubcommandRequiredElseHelp)
                 .subcommands(vec![
                     Command::new("docker")
-                        .about("Shows transparency logs for a Docker image")
+                        .about("Show transparency logs for a Docker image")
                         .arg_required_else_help(true)
                         .args(&[
                             arg!(--image <IMAGE> "The docker image (e.g. alpine:3.15.3 or alpine@sha256:1e014f84205d569a5cc3be4e108ca614055f7e21d11928946113ab3f36054801"),
                         ]),
                     Command::new("maven")
-                        .about("Shows transparency logs for a maven artifact")
+                        .about("Show transparency logs for a maven artifact")
                         .arg_required_else_help(true)
                         .args(&[
                             arg!(--gav <GAV> "The maven GAV (e.g. org.myorg:my-artifact:1.1.0)"),
                         ]),
                 ]),
-            Command::new("authorize")
-                .about("Pyrsia authorize command")
-                .arg_required_else_help(true)
-                .args(&[
-                    arg!(-p --peer <PEER_ID>      "Peer ID of the node to authorize"),
-                ]),
+            Command::new("list")
+                .short_flag('l')
+                .about("Show a list of connected peers"),
+            Command::new("ping").about("Pings configured pyrsia node"),
+            Command::new("status")
+                .short_flag('s')
+                .about("Show information about the Pyrsia node"),
         ])
         .version(version_string)
         .get_matches()

--- a/pyrsia_cli/src/cli/parser.rs
+++ b/pyrsia_cli/src/cli/parser.rs
@@ -77,6 +77,12 @@ pub fn cli_parser() -> ArgMatches {
                             arg!(--gav <GAV> "The maven GAV (e.g. org.myorg:my-artifact:1.1.0)"),
                         ]),
                 ]),
+            Command::new("authorize")
+                .about("Pyrsia authorize command")
+                .arg_required_else_help(true)
+                .args(&[
+                    arg!(-p --peer <PEER_ID>      "Peer ID of the node to authorize"),
+                ]),
         ])
         .version(version_string)
         .get_matches()

--- a/pyrsia_cli/src/main.rs
+++ b/pyrsia_cli/src/main.rs
@@ -64,6 +64,9 @@ async fn main() {
             }
             _ => {}
         },
+        Some(("authorize", _authorize_matches)) => {
+            request_authorize(_authorize_matches.get_one::<String>("peer").unwrap()).await;
+        }
         _ => {} //this should be handled by clap arg_required_else_help
     }
 }

--- a/pyrsia_cli/src/main.rs
+++ b/pyrsia_cli/src/main.rs
@@ -35,6 +35,9 @@ async fn main() {
                 config_show();
             }
         }
+        Some(("authorize", authorize_matches)) => {
+            authorize(authorize_matches.get_one::<String>("peer").unwrap()).await;
+        }
         Some(("build", build_matches)) => match build_matches.subcommand() {
             Some(("docker", docker_matches)) => {
                 request_docker_build(docker_matches.get_one::<String>("image").unwrap()).await;
@@ -64,9 +67,6 @@ async fn main() {
             }
             _ => {}
         },
-        Some(("authorize", _authorize_matches)) => {
-            request_authorize(_authorize_matches.get_one::<String>("peer").unwrap()).await;
-        }
         _ => {} //this should be handled by clap arg_required_else_help
     }
 }

--- a/pyrsia_node/src/main.rs
+++ b/pyrsia_node/src/main.rs
@@ -361,7 +361,7 @@ mod tests {
     #[test]
     fn setup_blockchain_success() {
         let (p2p_client, _, _) = p2p::setup_libp2p_swarm(100).unwrap();
-        let blockchain_service = setup_blockchain_service(p2p_client.clone());
+        let blockchain_service = setup_blockchain_service(p2p_client);
         assert!(blockchain_service.is_ok());
     }
 }

--- a/src/artifact_service/service.rs
+++ b/src/artifact_service/service.rs
@@ -755,9 +755,22 @@ mod tests {
 
         let keypair = Keypair::generate();
 
-        let (_command_receiver, p2p_client) = create_p2p_client(&keypair);
+        let (mut command_receiver, p2p_client) = create_p2p_client(&keypair);
         let (mut build_event_receiver, artifact_service) =
             create_artifact_service(&tmp_dir, &keypair, p2p_client.clone());
+
+        tokio::spawn(async move {
+            loop {
+                match command_receiver.recv().await {
+                    Some(Command::ListPeers { sender, .. }) => {
+                        let mut set = HashSet::new();
+                        set.insert(p2p_client.local_peer_id);
+                        let _ = sender.send(set);
+                    }
+                    _ => panic!("Command must match Command::ListPeers"),
+                }
+            }
+        });
 
         tokio::spawn(async move {
             loop {
@@ -773,6 +786,7 @@ mod tests {
         artifact_service
             .transparency_log_service
             .add_authorized_node(p2p_client.local_peer_id)
+            .await
             .unwrap();
 
         let package_type = PackageType::Docker;
@@ -802,10 +816,16 @@ mod tests {
         tokio::spawn(async move {
             loop {
                 match command_receiver.recv().await {
+                    Some(Command::ListPeers { sender, .. }) => {
+                        let _ = sender.send(HashSet::new());
+                    }
                     Some(Command::RequestBuild { sender, .. }) => {
                         let _ = sender.send(Ok(String::from("request_build_ok")));
                     }
-                    _ => panic!("Command must match Command::RequestBuild"),
+                    other => panic!(
+                        "Command must match Command::ListPeers or Command::RequestBuild, was: {:?}",
+                        other
+                    ),
                 }
             }
         });
@@ -815,6 +835,7 @@ mod tests {
         artifact_service
             .transparency_log_service
             .add_authorized_node(other_peer_id)
+            .await
             .unwrap();
 
         let package_type = PackageType::Docker;

--- a/src/cli_commands/node.rs
+++ b/src/cli_commands/node.rs
@@ -16,7 +16,8 @@
 
 use super::config::get_config;
 use crate::node_api::model::cli::{
-    RequestDockerBuild, RequestDockerLog, RequestMavenBuild, RequestMavenLog, Status,
+    RequestAddNode, RequestDockerBuild, RequestDockerLog, RequestMavenBuild, RequestMavenLog,
+    Status,
 };
 
 pub async fn ping() -> Result<String, reqwest::Error> {
@@ -56,6 +57,21 @@ pub async fn request_docker_build(request: RequestDockerBuild) -> Result<String,
 
 pub async fn request_maven_build(request: RequestMavenBuild) -> Result<String, reqwest::Error> {
     let node_url = format!("http://{}/build/maven", get_url());
+    let client = reqwest::Client::new();
+    match client
+        .post(node_url)
+        .json(&request)
+        .send()
+        .await?
+        .error_for_status()
+    {
+        Ok(response) => response.json::<String>().await,
+        Err(e) => Err(e),
+    }
+}
+
+pub async fn request_authorize(request: RequestAddNode) -> Result<String, reqwest::Error> {
+    let node_url = format!("http://{}/node/add", get_url());
     let client = reqwest::Client::new();
     match client
         .post(node_url)

--- a/src/cli_commands/node.rs
+++ b/src/cli_commands/node.rs
@@ -42,19 +42,16 @@ pub async fn status() -> Result<Status, reqwest::Error> {
 
 pub async fn add_authorized_node(
     request: RequestAddAuthorizedNode,
-) -> Result<String, reqwest::Error> {
+) -> Result<(), reqwest::Error> {
     let node_url = format!("http://{}/authorized_node", get_url());
     let client = reqwest::Client::new();
-    match client
+    client
         .post(node_url)
         .json(&request)
         .send()
         .await?
         .error_for_status()
-    {
-        Ok(response) => response.json::<String>().await,
-        Err(e) => Err(e),
-    }
+        .map(|_| ())
 }
 
 pub async fn request_docker_build(request: RequestDockerBuild) -> Result<String, reqwest::Error> {

--- a/src/cli_commands/node.rs
+++ b/src/cli_commands/node.rs
@@ -40,9 +40,7 @@ pub async fn status() -> Result<Status, reqwest::Error> {
     Ok(response)
 }
 
-pub async fn add_authorized_node(
-    request: RequestAddAuthorizedNode,
-) -> Result<(), reqwest::Error> {
+pub async fn add_authorized_node(request: RequestAddAuthorizedNode) -> Result<(), reqwest::Error> {
     let node_url = format!("http://{}/authorized_node", get_url());
     let client = reqwest::Client::new();
     client

--- a/src/cli_commands/node.rs
+++ b/src/cli_commands/node.rs
@@ -16,8 +16,8 @@
 
 use super::config::get_config;
 use crate::node_api::model::cli::{
-    RequestAddNode, RequestDockerBuild, RequestDockerLog, RequestMavenBuild, RequestMavenLog,
-    Status,
+    RequestAddAuthorizedNode, RequestDockerBuild, RequestDockerLog, RequestMavenBuild,
+    RequestMavenLog, Status,
 };
 
 pub async fn ping() -> Result<String, reqwest::Error> {
@@ -40,6 +40,23 @@ pub async fn status() -> Result<Status, reqwest::Error> {
     Ok(response)
 }
 
+pub async fn add_authorized_node(
+    request: RequestAddAuthorizedNode,
+) -> Result<String, reqwest::Error> {
+    let node_url = format!("http://{}/authorized_node", get_url());
+    let client = reqwest::Client::new();
+    match client
+        .post(node_url)
+        .json(&request)
+        .send()
+        .await?
+        .error_for_status()
+    {
+        Ok(response) => response.json::<String>().await,
+        Err(e) => Err(e),
+    }
+}
+
 pub async fn request_docker_build(request: RequestDockerBuild) -> Result<String, reqwest::Error> {
     let node_url = format!("http://{}/build/docker", get_url());
     let client = reqwest::Client::new();
@@ -57,21 +74,6 @@ pub async fn request_docker_build(request: RequestDockerBuild) -> Result<String,
 
 pub async fn request_maven_build(request: RequestMavenBuild) -> Result<String, reqwest::Error> {
     let node_url = format!("http://{}/build/maven", get_url());
-    let client = reqwest::Client::new();
-    match client
-        .post(node_url)
-        .json(&request)
-        .send()
-        .await?
-        .error_for_status()
-    {
-        Ok(response) => response.json::<String>().await,
-        Err(e) => Err(e),
-    }
-}
-
-pub async fn request_authorize(request: RequestAddNode) -> Result<String, reqwest::Error> {
-    let node_url = format!("http://{}/node/add", get_url());
     let client = reqwest::Client::new();
     match client
         .post(node_url)

--- a/src/docker/error_util.rs
+++ b/src/docker/error_util.rs
@@ -39,6 +39,7 @@ pub enum RegistryErrorCode {
     BlobUnknown,
     BlobDoesNotExist(String),
     ManifestUnknown,
+    BadRequest(String),
     Unknown(String),
 }
 
@@ -142,6 +143,10 @@ pub async fn custom_recover(err: Rejection) -> Result<impl Reply, Infallible> {
             RegistryErrorCode::ManifestUnknown => {
                 status_code = StatusCode::NOT_FOUND;
                 error_message.code = RegistryErrorCode::ManifestUnknown;
+            }
+            RegistryErrorCode::BadRequest(m) => {
+                status_code = StatusCode::BAD_REQUEST;
+                error_message.message = m.clone();
             }
             RegistryErrorCode::Unknown(m) => {
                 error_message.message = m.clone();

--- a/src/node_api/handlers/swarm.rs
+++ b/src/node_api/handlers/swarm.rs
@@ -18,7 +18,7 @@ use crate::artifact_service::model::PackageType;
 use crate::docker::error_util::RegistryError;
 use crate::network::client::Client;
 use crate::node_api::model::cli::{
-    RequestDockerBuild, RequestDockerLog, RequestMavenBuild, RequestMavenLog,
+    RequestAddNode, RequestDockerBuild, RequestDockerLog, RequestMavenBuild, RequestMavenLog,
 };
 use crate::transparency_log::log::TransparencyLogService;
 
@@ -41,6 +41,23 @@ pub async fn handle_build_docker(
         .header("Content-Type", "application/json")
         .status(StatusCode::OK)
         .body(build_id_as_json))
+}
+
+pub async fn handle_add_authorized_node(
+    request_add_node: RequestAddNode,
+    mut transparency_log_service: TransparencyLogService,
+) -> Result<impl Reply, Rejection> {
+    transparency_log_service
+        .request_add_authorized_node(request_add_node.peer_id.as_str())
+        .await
+        .map_err(RegistryError::from)?;
+
+    let json = serde_json::to_string("OK").map_err(RegistryError::from)?;
+
+    Ok(warp::http::response::Builder::new()
+        .header("Content-Type", "application/json")
+        .status(StatusCode::OK)
+        .body(json))
 }
 
 pub async fn handle_build_maven(

--- a/src/node_api/model/cli.rs
+++ b/src/node_api/model/cli.rs
@@ -24,6 +24,11 @@ pub struct Status {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+pub struct RequestAddNode {
+    pub peer_id: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 pub struct RequestDockerBuild {
     pub image: String,
 }

--- a/src/node_api/model/cli.rs
+++ b/src/node_api/model/cli.rs
@@ -24,7 +24,7 @@ pub struct Status {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-pub struct RequestAddNode {
+pub struct RequestAddAuthorizedNode {
     pub peer_id: String,
 }
 

--- a/src/node_api/routes.rs
+++ b/src/node_api/routes.rs
@@ -18,7 +18,7 @@ use super::handlers::swarm::*;
 use super::model::cli::{RequestDockerBuild, RequestMavenBuild};
 use crate::artifact_service::service::ArtifactService;
 use crate::network::client::Client;
-use crate::node_api::model::cli::{RequestDockerLog, RequestMavenLog};
+use crate::node_api::model::cli::{RequestAddNode, RequestDockerLog, RequestMavenLog};
 use crate::transparency_log::log::TransparencyLogService;
 use warp::Filter;
 
@@ -38,6 +38,14 @@ pub fn make_node_routes(
         .and(warp::body::json::<RequestDockerBuild>())
         .and(artifact_service_filter.clone())
         .and_then(handle_build_docker);
+
+    let add_node = warp::path!("node" / "add")
+        .and(warp::post())
+        .and(warp::path::end())
+        .and(warp::body::content_length_limit(1024 * 8))
+        .and(warp::body::json::<RequestAddNode>())
+        .and(transparency_log_service_filter.clone())
+        .and_then(handle_add_authorized_node);
 
     let build_maven = warp::path!("build" / "maven")
         .and(warp::post())
@@ -81,7 +89,8 @@ pub fn make_node_routes(
             .or(peers)
             .or(status)
             .or(inspect_docker)
-            .or(inspect_maven),
+            .or(inspect_maven)
+            .or(add_node),
     )
 }
 

--- a/src/node_api/routes.rs
+++ b/src/node_api/routes.rs
@@ -18,7 +18,7 @@ use super::handlers::swarm::*;
 use super::model::cli::{RequestDockerBuild, RequestMavenBuild};
 use crate::artifact_service::service::ArtifactService;
 use crate::network::client::Client;
-use crate::node_api::model::cli::{RequestAddNode, RequestDockerLog, RequestMavenLog};
+use crate::node_api::model::cli::{RequestAddAuthorizedNode, RequestDockerLog, RequestMavenLog};
 use crate::transparency_log::log::TransparencyLogService;
 use warp::Filter;
 
@@ -31,6 +31,14 @@ pub fn make_node_routes(
     let p2p_client_filter = warp::any().map(move || p2p_client.clone());
     let transparency_log_service_filter = warp::any().map(move || transparency_log_service.clone());
 
+    let add_authorized_node = warp::path!("authorized_node")
+        .and(warp::post())
+        .and(warp::path::end())
+        .and(warp::body::content_length_limit(1024 * 8))
+        .and(warp::body::json::<RequestAddAuthorizedNode>())
+        .and(transparency_log_service_filter.clone())
+        .and_then(handle_add_authorized_node);
+
     let build_docker = warp::path!("build" / "docker")
         .and(warp::post())
         .and(warp::path::end())
@@ -38,14 +46,6 @@ pub fn make_node_routes(
         .and(warp::body::json::<RequestDockerBuild>())
         .and(artifact_service_filter.clone())
         .and_then(handle_build_docker);
-
-    let add_node = warp::path!("node" / "add")
-        .and(warp::post())
-        .and(warp::path::end())
-        .and(warp::body::content_length_limit(1024 * 8))
-        .and(warp::body::json::<RequestAddNode>())
-        .and(transparency_log_service_filter.clone())
-        .and_then(handle_add_authorized_node);
 
     let build_maven = warp::path!("build" / "maven")
         .and(warp::post())
@@ -84,13 +84,13 @@ pub fn make_node_routes(
         .and_then(handle_inspect_log_maven);
 
     warp::any().and(
-        build_docker
+        add_authorized_node
+            .or(build_docker)
             .or(build_maven)
             .or(peers)
             .or(status)
             .or(inspect_docker)
-            .or(inspect_maven)
-            .or(add_node),
+            .or(inspect_maven),
     )
 }
 
@@ -163,11 +163,54 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn node_routes_add_authorized_node() {
+        let tmp_dir = test_util::tests::setup();
+
+        let local_keypair = Keypair::generate_ed25519();
+        let (mut command_receiver, p2p_client) = create_p2p_client(&local_keypair);
+        let transparency_log_service =
+            create_transparency_log_service(&tmp_dir, local_keypair.clone(), p2p_client.clone());
+
+        let (_build_event_receiver, artifact_service) = create_artifact_service(
+            &tmp_dir,
+            transparency_log_service.clone(),
+            p2p_client.clone(),
+        );
+
+        tokio::spawn(async move {
+            loop {
+                match command_receiver.recv().await {
+                    Some(Command::ListPeers { sender, .. }) => {
+                        let _ = sender.send(HashSet::new());
+                    }
+                    _ => panic!("Command must match Command::ListPeers"),
+                }
+            }
+        });
+
+        let filter = make_node_routes(artifact_service, p2p_client, transparency_log_service);
+        let request = RequestAddAuthorizedNode {
+            peer_id: local_keypair.public().to_peer_id().to_string(),
+        };
+        let response = warp::test::request()
+            .method("POST")
+            .path("/authorized_node")
+            .json(&request)
+            .reply(&filter)
+            .await;
+
+        assert_eq!(response.status(), 201);
+        assert_eq!(response.body(), "");
+
+        test_util::tests::teardown(tmp_dir);
+    }
+
+    #[tokio::test]
     async fn node_routes_build_docker() {
         let tmp_dir = test_util::tests::setup();
 
         let local_keypair = Keypair::generate_ed25519();
-        let (_command_receiver, p2p_client) = create_p2p_client(&local_keypair);
+        let (mut command_receiver, p2p_client) = create_p2p_client(&local_keypair);
         let transparency_log_service =
             create_transparency_log_service(&tmp_dir, local_keypair.clone(), p2p_client.clone());
 
@@ -177,8 +220,20 @@ mod tests {
             p2p_client.clone(),
         );
 
+        tokio::spawn(async move {
+            loop {
+                match command_receiver.recv().await {
+                    Some(Command::ListPeers { sender, .. }) => {
+                        let _ = sender.send(HashSet::new());
+                    }
+                    _ => panic!("Command must match Command::ListPeers"),
+                }
+            }
+        });
+
         transparency_log_service
             .add_authorized_node(local_keypair.public().to_peer_id())
+            .await
             .expect("Error adding authorized node");
 
         let build_id = uuid::Uuid::new_v4();
@@ -217,7 +272,7 @@ mod tests {
         let tmp_dir = test_util::tests::setup();
 
         let local_keypair = Keypair::generate_ed25519();
-        let (_command_receiver, p2p_client) = create_p2p_client(&local_keypair);
+        let (mut command_receiver, p2p_client) = create_p2p_client(&local_keypair);
         let transparency_log_service =
             create_transparency_log_service(&tmp_dir, local_keypair.clone(), p2p_client.clone());
 
@@ -227,8 +282,20 @@ mod tests {
             p2p_client.clone(),
         );
 
+        tokio::spawn(async move {
+            loop {
+                match command_receiver.recv().await {
+                    Some(Command::ListPeers { sender, .. }) => {
+                        let _ = sender.send(HashSet::new());
+                    }
+                    _ => panic!("Command must match Command::ListPeers"),
+                }
+            }
+        });
+
         transparency_log_service
             .add_authorized_node(local_keypair.public().to_peer_id())
+            .await
             .expect("Error adding authorized node");
 
         let build_id = uuid::Uuid::new_v4();

--- a/src/transparency_log/log.rs
+++ b/src/transparency_log/log.rs
@@ -216,6 +216,52 @@ impl TransparencyLogService {
         Ok(transparency_log)
     }
 
+    pub async fn request_add_authorized_node(
+        &mut self,
+        peer_id: &str,
+    ) -> Result<(), anyhow::Error> {
+        let add_node_transparency_log = self.create_add_node(peer_id).unwrap();
+
+        let payload = serde_json::to_string(&add_node_transparency_log).unwrap();
+
+        let _ = self
+            .blockchain_service
+            .lock()
+            .await
+            .add_payload(payload.into_bytes())
+            .await;
+
+        self.write_transparency_log(&add_node_transparency_log)?;
+
+        Ok(())
+    }
+
+    pub fn create_add_node(
+        &mut self,
+        peer_id: &str,
+    ) -> Result<TransparencyLog, TransparencyLogError> {
+        let transparency_log = TransparencyLog {
+            id: Uuid::new_v4().to_string(),
+            package_type: None,
+            package_specific_id: String::from(""),
+            num_artifacts: 0,
+            package_specific_artifact_id: String::from(""),
+            artifact_hash: String::from(""),
+            source_hash: String::from(""),
+            artifact_id: String::from(""),
+            source_id: String::from(""),
+            timestamp: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+            operation: Operation::AddNode,
+            node_id: peer_id.to_string(),
+            node_public_key: Uuid::new_v4().to_string(),
+        };
+
+        Ok(transparency_log)
+    }
+
     /// Adds a transparency log with the RemoveArtifact operation.
     pub fn remove_artifact(
         &mut self,


### PR DESCRIPTION
## Description

Fixes pyrsia/pyrsia#1083

This PR allows to add an authorize node by running a CLI command to request the addition of a peer_id as the authorized node.

You can test by starting a node and then run:
```sh
pyrsia authorize --peer <YOUR_NODE_PEER_ID>
```

## PR Checklist

<!-- Make certain you've done the following. -->

- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/get_involved/good_pr.md)
- [x] I've included a good title and brief description along with how to review them.
- [x] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).

### Code Contributions

<!--

This section applies to code modifications, you may remove it otherwise.

Make sure your Pull Request will pass the CI/CD pipeline.
For a complete list of steps, check out the [developer workflow](https://github.com/pyrsia/pyrsia/blob/main/docs/get_involved/dev_workflow.md)!

-->

- [x] I've built the code `cargo build --all-targets` successfully.
- [x] I've run the unit tests `cargo test --workspace` and everything passes.
- [x] I've made sure my rust toolchain is current `rustup update`.
