### PR TITLE
Add  --init-blockchain and update to run on nightly cluster

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -146,7 +146,7 @@ jobs:
       if: github.repository_owner == 'pyrsia' && (github.event_name == 'push' || github.event_name == 'release')
       run: |
         sudo go install github.com/mikefarah/yq/v4@latest
-        yq e '.image.tag |= "0.1.0+${{ github.run_number }}"' -i installers/helm/pyrsia-node/values.yaml
+        yq e '.image.tag |= "0.1.0-${{ github.run_number }}"' -i installers/helm/pyrsia-node/values.yaml
         yq e '.version |= "0.1.0+${{ github.run_number }}"' -i installers/helm/pyrsia-node/Chart.yaml
         yq e '.appVersion |= "0.1.0+${{ github.run_number }}"' -i installers/helm/pyrsia-node/Chart.yaml
 

--- a/installers/docker/AptGet.Dockerfile
+++ b/installers/docker/AptGet.Dockerfile
@@ -6,9 +6,11 @@ EXPOSE 44000
 
 # Send logging to stdout and stderr
 ENV RUST_LOG=info
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PYRSIA_BOOTDNS=boot.pyrsia.link
 
 RUN apt-get update; \
-    apt-get -y install ca-certificates wget gnupg2 jq curl; \
+    apt-get -y install ca-certificates wget gnupg2 jq curl dnsutils; \
     wget -O - https://pyrsia.io/install.sh | sh; 
 
 # Need to run an entrypoint script that will determine if the docker container

--- a/installers/docker/node-entrypoint.sh
+++ b/installers/docker/node-entrypoint.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-set -e
+
+set -x
 
 # determine if we are running under kubernetes
 if [ -f /var/run/secrets/kubernetes.io/serviceaccount/namespace ]; then
@@ -10,17 +11,48 @@ if [ -f /var/run/secrets/kubernetes.io/serviceaccount/namespace ]; then
     CACERT=${SERVICEACCOUNT}/ca.crt
     PODNAME=`hostname`
     export PYRSIA_EXTERNAL_IP=$(curl -s --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -X GET ${APISERVER}/api/v1/namespaces/${NAMESPACE}/services/${PODNAME} | jq -r ".status.loadBalancer.ingress[0].ip")
+
+    # Wait for the service to be assigned an ip addr
+    while [ "${PYRSIA_EXTERNAL_IP}" == "" ] || [ "${PYRSIA_EXTERNAL_IP}" == "null" ]; do
+        sleep 5
+        export PYRSIA_EXTERNAL_IP=$(curl -s --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -X GET ${APISERVER}/api/v1/namespaces/${NAMESPACE}/services/${PODNAME} | jq -r ".status.loadBalancer.ingress[0].ip")
+    done
     echo "PYRSIA_EXTERNAL_IP=$PYRSIA_EXTERNAL_IP"
 
+    NODE_DOMAIN=$(echo $PYRSIA_BOOTDNS | cut -d'.' -f2-)
+    NODE_HOSTNAME=${HOSTNAME}.${NODE_DOMAIN}
+ 
+    # Wait for the ip addr to be mapped to dns and propogated
+
+    DNSREADY=$(dig ${NODE_HOSTNAME} 2>&1 | grep "${PYRSIA_EXTERNAL_IP}")
+    while [ "${DNSREADY}" == ""  ]; do
+        sleep 5
+        DNSREADY=$(dig ${NODE_HOSTNAME} 2>&1 | grep "${PYRSIA_EXTERNAL_IP}")
+    done
+
     # detemine if I am pyrsia-node-0.pyrsia.link (first boot node ever) if so be the primary boot node
-    # need to use wget since nslookup, dig and ping are not installed
-    if wget --timeout=2 -v pyrsia-node-0.pyrsia.link 2>&1 | grep Connecting | grep -q "${PYRSIA_EXTERNAL_IP}" ; then  
+
+    echo Find Boot Zero
+    echo ${DNSREADY}
+    echo DONE
+
+    BOOTZERO=$(echo "${DNSREADY}" | grep "${PYRSIA_BOOTDNS}")
+    if  [ "${BOOTZERO}" != "" ]; then  
         /usr/bin/pyrsia_node $* --listen-only --init-blockchain
-    else
-        # I am not pyrsia-node-0.pyrsia.link so use boot.pyrsia.link for boot address and connect to it
-        /usr/bin/pyrsia_node $*
+        exit $?
     fi
-else
-    # not running under k8s so just startup in default mode
-    /usr/bin/pyrsia_node $*
 fi
+
+# I am not node-0 so use boot.pyrsia.link for boot address and connect to it
+
+# Wait for the status from node-0 to be available
+curl http://${PYRSIA_BOOTDNS}/status
+
+BOOTADDR=$(curl -s http://${PYRSIA_BOOTDNS}/status | jq -r ".peer_addrs[0]")
+
+while [ "${BOOTADDR}" == "" ] || [ "${BOOTADDR}" == "null" ]; do
+    sleep 5
+    BOOTADDR=$(curl -s http://${PYRSIA_BOOTDNS}/status | jq -r ".peer_addrs[0]")
+done
+
+/usr/bin/pyrsia_node $* -P $BOOTADDR

--- a/installers/helm/pyrsia-node/Chart.yaml
+++ b/installers/helm/pyrsia-node/Chart.yaml
@@ -2,8 +2,8 @@
 apiVersion: v2
 description: Pyrsia Decentralized Package Network
 name: pyrsia-node
-appVersion: 0.1.0+2302
-version: 0.1.0+2302
+appVersion: 0.1.0+2305
+version: 0.1.0+2305
 home: https://pyrsia.io
 icon: https://raw.githubusercontent.com/pyrsia/pyrsia.github.io/main/static/img/icon-pyrsia-torch.svg
 keywords: 

--- a/installers/helm/pyrsia-node/Chart.yaml
+++ b/installers/helm/pyrsia-node/Chart.yaml
@@ -2,8 +2,8 @@
 apiVersion: v2
 description: Pyrsia Decentralized Package Network
 name: pyrsia-node
-appVersion: 0.1.0+2252
-version: 0.1.0+2252
+appVersion: 0.1.0+2302
+version: 0.1.0+2302
 home: https://pyrsia.io
 icon: https://raw.githubusercontent.com/pyrsia/pyrsia.github.io/main/static/img/icon-pyrsia-torch.svg
 keywords: 

--- a/installers/helm/pyrsia-node/templates/clusterrole.yaml
+++ b/installers/helm/pyrsia-node/templates/clusterrole.yaml
@@ -13,14 +13,20 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ printf "%s-service-reader" (include "pyrsia-node.name" .) }}
-  namespace: kube-system 
 subjects:
   - kind: ServiceAccount
     # Reference to upper's `metadata.name`
-    name: default
+    name: {{ printf "%s-service-reader" (include "pyrsia-node.name" .) }}
     # Reference to upper's `metadata.namespace`
-    namespace: kube-system
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: {{ printf "%s-service-reader" (include "pyrsia-node.name" .) }}
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ printf "%s-service-reader" (include "pyrsia-node.name" .) }}
+  namespace: {{ .Release.Namespace }}
+---

--- a/installers/helm/pyrsia-node/templates/deployment.yaml
+++ b/installers/helm/pyrsia-node/templates/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         tier: frontend
         track: stable
     spec:
+      serviceAccount: {{ printf "%s-service-reader" (include "pyrsia-node.name" .) }}
       containers:
         - name: {{ include "pyrsia-node.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -34,6 +35,8 @@ spec:
               value: "/usr/local/var/pyrsia"
             - name: PYRSIA_KEYPAIR
               value: /usr/local/var/pyrsia-p2p-keys/ed25519.ser
+            - name: PYRSIA_BOOTDNS
+              value: {{ printf "%s-0.%s" (include "pyrsia-node.name" .) (.Values.bootdns | default "pyrsia.link") }}   
           volumeMounts:
             # name must match the volume name below
             - name: pyrsia-storage

--- a/installers/helm/pyrsia-node/templates/service.yaml
+++ b/installers/helm/pyrsia-node/templates/service.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ printf "%s-0" (include "pyrsia-node.name" .) }}
   annotations:
     external-dns.alpha.kubernetes.io/hostname: {{ printf "%s-0.%s" (include "pyrsia-node.name" .) .Values.dnsname }} 
+    external-dns.alpha.kubernetes.io/ttl: "60"
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local
@@ -25,7 +26,8 @@ apiVersion: v1
 metadata:
   name: {{ printf "%s-1" (include "pyrsia-node.name" .) }}
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: {{ printf "%s-1.%s" (include "pyrsia-node.name" .) .Values.dnsname }}     
+    external-dns.alpha.kubernetes.io/hostname: {{ printf "%s-1.%s" (include "pyrsia-node.name" .) .Values.dnsname }}
+    external-dns.alpha.kubernetes.io/ttl: "60"     
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local
@@ -46,7 +48,8 @@ apiVersion: v1
 metadata:
   name: {{ printf "%s-2" (include "pyrsia-node.name" .) }}
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: {{ printf "%s-2.%s" (include "pyrsia-node.name" .) .Values.dnsname }}    
+    external-dns.alpha.kubernetes.io/hostname: {{ printf "%s-2.%s" (include "pyrsia-node.name" .) .Values.dnsname }} 
+    external-dns.alpha.kubernetes.io/ttl: "60"   
 spec:
   type: LoadBalancer
   selector:

--- a/installers/helm/pyrsia-node/values.yaml
+++ b/installers/helm/pyrsia-node/values.yaml
@@ -5,8 +5,8 @@ dnsname: pyrsia.link
 replicaCount: 1
 
 image:
-  repository: sbtaylor15/pyrsia-node
-  tag: 0.1.0-fix
+  repository: pyrsiaoss/pyrsia-node
+  tag: 0.1.0-2305
   pullPolicy: Always
 
 p2pkeys:

--- a/installers/helm/pyrsia-node/values.yaml
+++ b/installers/helm/pyrsia-node/values.yaml
@@ -5,8 +5,8 @@ dnsname: pyrsia.link
 replicaCount: 1
 
 image:
-  repository: pyrsiaoss/pyrsia-node
-  tag: 0.1.0-2252
+  repository: sbtaylor15/pyrsia-node
+  tag: 0.1.0-fix
   pullPolicy: Always
 
 p2pkeys:


### PR DESCRIPTION
<!--

Thank you for participating with our effort to build a more secure software supply chain.
Before submitting your Pull Request, please go over our check list.

-->

## Description

This PR uses the latest image with --listen-only --init-blockchain parameters.  The logic in the entrypoint.sh and helm charts have been modified to handle running on the nightly cluster (outside of boot.pyrsia.link).   Looping was added to wait for resources to be available and valid before moving onto the next step in bringing up the nodes.

<!--

Try to fill in the following to help the reviewers dive into the pull request.
Explain the context and what changed.

-->

Fixes pyrsia/pyrsia#904
Fixes pyrsia/pyrsia#1114


## Screenshots (optional)

## PR Checklist

<!-- Make certain you've done the following. -->

- [X] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [X] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/get_involved/good_pr.md)
- [X] I've included a good title and brief description along with how to review them.
- [X] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).

### Code Contributions

<!--

This section applies to code modifications, you may remove it otherwise.

Make sure your Pull Request will pass the CI/CD pipeline.
For a complete list of steps, check out the [developer workflow](https://github.com/pyrsia/pyrsia/blob/main/docs/get_involved/dev_workflow.md)!

-->

- [X] I've built the code `cargo build --all-targets` successfully.
- [X] I've run the unit tests `cargo test --workspace` and everything passes.
- [X] I've made sure my rust toolchain is current `rustup update`.
