### PR TITLE
Upload each MSI installer in its own zip

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -102,13 +102,17 @@ jobs:
           cd ../..
 
       # for now, upload installers
-      - name: Upload Artifact
+      - name: Upload Installer
         uses: actions/upload-artifact@v3
         with:
-          name: windows-installers
-          path: |
-            ${{ github.workspace }}/installers/windows/pyrsia.msi
-            ${{ github.workspace }}/installers/windows/pyrsia_service.msi
+          name: windows-installer
+          path: ${{ github.workspace }}/installers/windows/pyrsia.msi
+
+      - name: Upload Installer_with_Service
+        uses: actions/upload-artifact@v3
+        with:
+          name: windows-installer-with-service
+          path: ${{ github.workspace }}/installers/windows/pyrsia_service.msi
 
   build-push-linux:
     permissions:


### PR DESCRIPTION
<!--

Thank you for participating with our effort to build a more secure software supply chain.
Before submitting your Pull Request, please go over our check list.

-->

## Description

<!--

Try to fill in the following to help the reviewers dive into the pull request.
Explain the context and what changed.

-->

Fixes pyrsia/pyrsia#1154

This PR modifies the rust workflow to publish each of the two MSI Windows installer in separated zip files.

## Screenshots (optional)

## PR Checklist

<!-- Make certain you've done the following. -->

- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/get_involved/good_pr.md)
- [x] I've included a good title and brief description along with how to review them.
- [x] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).

### Code Contributions

<!--

This section applies to code modifications, you may remove it otherwise.

Make sure your Pull Request will pass the CI/CD pipeline.
For a complete list of steps, check out the [developer workflow](https://github.com/pyrsia/pyrsia/blob/main/docs/get_involved/dev_workflow.md)!

-->

- [x] I've built the code `cargo build --all-targets` successfully.
- [x] I've run the unit tests `cargo test --workspace` and everything passes.
- [x] I've made sure my rust toolchain is current `rustup update`.
