### PR TITLE
Improve tutorials for Docker setup

### DIFF
--- a/docs/tutorials/docker.md
+++ b/docs/tutorials/docker.md
@@ -18,7 +18,7 @@ First, make sure to complete the steps in the [installation tutorial](/docs/tuto
 
 Next, configure your Docker installation to use Pyrsia as a registry mirror.
 
-On Windows or macOS, open your Docker desktop installation -> Settings ->
+On Windows or macOS, open your Docker Desktop -> Settings ->
 Docker Engine where Docker allows you to set registry-mirrors. Configure your node
 as a registry mirror by adding/editing the following in the configuration:
 

--- a/docs/tutorials/quick-installation.mdx
+++ b/docs/tutorials/quick-installation.mdx
@@ -159,7 +159,7 @@ you can also choose to run our pre-built Docker image available in [Docker Hub](
 
 ### Docker
 
-Make sure you have Docker installed on your system and run in the background:
+Make sure you have Docker installed on your system and run in the background:  
 (Add an option `-e RUST_LOG=debug` to change the log level from the default value, `info`.)
 
 ```sh
@@ -201,7 +201,7 @@ Add the following setting to change the log level (`info` is set as a default va
 ```yaml
 services:
   pyrsia:
-    environment:       # This is optional.
+    environment: # This is optional.
       - RUST_LOG=debug
 ```
 

--- a/docs/tutorials/quick-installation.mdx
+++ b/docs/tutorials/quick-installation.mdx
@@ -155,15 +155,33 @@ Now you are ready to follow the instructions in [Configure Docker to use Pyrsia]
 ## Run Pyrsia in Docker
 
 As a temporary alternative to the installation scripts for the supported platforms,
-you can also choose to run our pre-built Docker image available in [Docker Hub](https://hub.docker.com/r/pyrsiaoss/pyrsia-node)
+you can also choose to run our pre-built Docker image available in [Docker Hub](https://hub.docker.com/r/pyrsiaoss/pyrsia-node).
 
-Make sure you have Docker installed on your system and run:
+### Docker
+
+Make sure you have Docker installed on your system and run in the background:
+(Add an option `-e RUST_LOG=debug` to change the log level from the default value, `info`.)
 
 ```sh
-docker run -p 7888:7888 pyrsiaoss/pyrsia-node:0.2.0-2342
+docker run -d -p 7888:7888 --name pyrsia_node pyrsiaoss/pyrsia-node:0.2.0-2342
 ```
 
-Or use this `docker-compose.yml` file:
+Tail the logs to check if Pyrsia started correctly:
+
+```sh
+docker logs -f pyrsia_node
+```
+
+Or use the pyrsia CLI like this:
+
+```sh
+docker exec pyrsia_node pyrsia ping
+Connection Successful !!
+```
+
+### Docker Compose
+
+Use this `docker-compose.yml` file:
 
 ```yaml
 services:
@@ -178,7 +196,16 @@ volumes:
   pyrsia:
 ```
 
-And start running Pyrsia in the background:
+Add the following setting to change the log level (`info` is set as a default value):
+
+```yaml
+services:
+  pyrsia:
+    environment:       # This is optional.
+      - RUST_LOG=debug
+```
+
+Start running Pyrsia in the background:
 
 ```sh
 docker-compose up -d

--- a/docs/tutorials/quick-installation.mdx
+++ b/docs/tutorials/quick-installation.mdx
@@ -159,7 +159,8 @@ you can also choose to run our pre-built Docker image available in [Docker Hub](
 
 ### Docker
 
-Make sure you have Docker installed on your system and run in the background:  
+Make sure you have Docker installed on your system and run in the background:
+
 (Add an option `-e RUST_LOG=debug` to change the log level from the default value, `info`.)
 
 ```sh

--- a/docs/tutorials/quick-installation.mdx
+++ b/docs/tutorials/quick-installation.mdx
@@ -186,7 +186,7 @@ Use this `docker-compose.yml` file:
 ```yaml
 services:
   pyrsia:
-    image: pyrsiaoss/pyrsia-node:0.1.0-2338
+    image: pyrsiaoss/pyrsia-node:0.2.0-2342
     ports:
       - "7888:7888"
     volumes:

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ Let's exercise the [Docker](https://www.docker.com/) integration.
 
 Configure your Docker installation to use Pyrsia as a registry mirror.
 
-On Windows or macOS, open your Docker desktop installation -> Settings ->
+On Windows or macOS, open your Docker Desktop -> Settings ->
 Docker Engine where Docker allows you to set registry-mirrors. Configure your node
 as a registry mirror by adding/editing the following in the configuration:
 


### PR DESCRIPTION
## Description

Improved the tutorial docs not to get confused when a user run Pyrsia on Docker.

- Separated Docker and Docker Compose as which step should be done is not so clear.
- Added some procedures as a preparation for the next step: https://pyrsia.io/docs/tutorials/docker/
- Changed the image version in `docker-compose.yml`.
- Fixed typo.

I added some comments to a specific line to tell why I changed, too.

Fixes pyrsia/pyrsia#

## Screenshots (optional)
Main change is like this (Moved at my local env):
<img width="596" alt="image" src="https://user-images.githubusercontent.com/8938191/195476552-3401ed2f-5ed5-4ae7-993c-f215f0c6c815.png">


## PR Checklist

<!-- Make certain you've done the following. -->

- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/get_involved/good_pr.md)
- [x] I've included a good title and brief description along with how to review them.
- [x] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).