### PR TITLE
remove use of `-H 0.0.0.0` in docs

### DIFF
--- a/docs/developers/build_from_source_docker.md
+++ b/docs/developers/build_from_source_docker.md
@@ -205,7 +205,7 @@ of node A. This multiaddress can be found in the logs of node A (see section
 
 ```sh
 RUST_LOG=pyrsia=debug DEV_MODE=on \
-./pyrsia_node -H 0.0.0.0 --peer /ip4/127.0.0.1/tcp/56662/p2p/12D3KooWBgWeXNT1EKXo2omRhZVmkbvPgzZ5BcGjTfgKr586BSAn
+./pyrsia_node --peer /ip4/127.0.0.1/tcp/56662/p2p/12D3KooWBgWeXNT1EKXo2omRhZVmkbvPgzZ5BcGjTfgKr586BSAn
 ```
 
 **Important**: do not simply copy/paste this command, the multiaddress on your

--- a/docs/developers/setting_up_ide.md
+++ b/docs/developers/setting_up_ide.md
@@ -20,7 +20,7 @@ Before continuing please make sure that you have cloned and compiled the Pyrsia 
 - Rename the configuration to `Run Node`.
 - In the `Command` field past the following:
 
-`run --package pyrsia_node -- --pipeline-service-endpoint http://localhost:8080 --host 0.0.0.0 --port 7888 --listen /ip4/0.0.0.0/tcp/44002`
+`run --package pyrsia_node -- --pipeline-service-endpoint http://localhost:8080 --port 7888 --listen /ip4/0.0.0.0/tcp/44002`
 
 - Add the following vars to the `Environment Variables`:
 

--- a/docs/tutorials/docker.md
+++ b/docs/tutorials/docker.md
@@ -36,7 +36,9 @@ performed for you.
 > In general you would specify `localhost:7888` as the registry mirror but on MacOS
 > and Windows this won't work because Docker Engine is running in a VM, which is
 > not the same as the local host your Pyrsia is running on. Using `0.0.0.0` works
-> around this issue.
+> around this issue. In case you're having issues, try specifying your host IP address
+> as the registry-mirror and bind your local Pyrsia node to that IP (using `-H`
+> with an explicit IP address or using `-H 0.0.0.0`)
 
 You will need to restart Docker Desktop. Once restarted you should be able to
 pull Docker images through Pyrsia.

--- a/docs/tutorials/docker.md
+++ b/docs/tutorials/docker.md
@@ -24,8 +24,7 @@ as a registry mirror by adding/editing the following in the configuration:
 
 ```jsonc
  "registry-mirrors": [
-   "http://192.168.0.110:7888" // (IP address of your host machine and port number
-                               //  of your Pyrsia node, which is 7888 by default)
+   "http://0.0.0.0:7888"
  ]
 ```
 
@@ -33,9 +32,11 @@ On Linux, you'll find this configuration in the file `/etc/docker/daemon.json`.
 If you've run the apt installation, this step was already automatically
 performed for you.
 
-> On macOS or Windows, you can't specify `localhost` because the request to Pyrsia
-will originate from the Docker Desktop VM, so you will need to specify the IP
-address of your host machine. On Linux you can use localhost.
+> **Why 0.0.0.0?** \
+> In general you would specify `localhost:7888` as the registry mirror but on MacOS
+> and Windows this won't work because Docker Engine is running in a VM, which is
+> not the same as the local host your Pyrsia is running on. Using `0.0.0.0` works
+> around this issue.
 
 You will need to restart Docker Desktop. Once restarted you should be able to
 pull Docker images through Pyrsia.

--- a/readme.md
+++ b/readme.md
@@ -54,12 +54,14 @@ as a registry mirror by adding/editing the following in the configuration:
 
 ```jsonc
  "registry-mirrors": [
-   "http://192.168.0.110:7888" // (IP address of your host machine and port number
-                               //  of your Pyrsia node, which is 7888 by default)
+   "http://0.0.0.0:7888"
  ]
 ```
 
 On Linux, you'll find this configuration in the file `/etc/docker/daemon.json`.
+
+See [this page](/docs/tutorials/docker/#configure-docker) for more information about
+configuring Docker.
 
 Let's try to pull an artifact from the Pyrsia network, but first make sure it is
 not yet in your local Docker cache:


### PR DESCRIPTION
## Description

Fixes #1189

This PR does removes the need to use `-H 0.0.0.0` in the docs. The pyrsia_node can always bind to default (localhost) while the Docker registry mirror settings can be improved to be able to use that locally bound pyrsia node.

## PR Checklist

<!-- Make certain you've done the following. -->

- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/community/get_involved/good_pr.md)
- [x] I've included a good title and brief description along with how to review them.
- [x] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).

