### PR TITLE
restart pod when unhealthy and deploy service based on replica Count

### DIFF
--- a/installers/helm/pyrsia-node/templates/deployment.yaml
+++ b/installers/helm/pyrsia-node/templates/deployment.yaml
@@ -43,6 +43,12 @@ spec:
             - name: PYRSIA_BUILDNODE
               value: {{ .Values.buildnode }}
             {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: 7888
+            initialDelaySeconds: 360
+            periodSeconds: 60
           volumeMounts:
             # name must match the volume name below
             - name: pyrsia-storage

--- a/installers/helm/pyrsia-node/templates/service.yaml
+++ b/installers/helm/pyrsia-node/templates/service.yaml
@@ -21,6 +21,7 @@ spec:
       protocol: TCP
       name: p2p
 ---
+{{ if ge .Values.replicaCount 2 }}
 kind: Service
 apiVersion: v1
 metadata:
@@ -42,7 +43,9 @@ spec:
       targetPort: 44000
       protocol: TCP
       name: p2p
+{{ end }}
 ---
+{{ if ge .Values.replicaCount 3 }}
 kind: Service
 apiVersion: v1
 metadata:
@@ -63,4 +66,5 @@ spec:
       targetPort: 44000
       protocol: TCP
       name: p2p
+{{ end }}
 ---


### PR DESCRIPTION
<!--

Thank you for participating with our effort to build a more secure software supply chain.
Before submitting your Pull Request, please go over our check list.

-->

## Description

Added liveliness probe to check /status returns 200.  If the probe returns any other than 2XX the pod will be restarted.  Also, added if statements to check the replica count to prevent unused services from being deployed.

**NOTE: This needs to be merged after #1232**

<!--

Try to fill in the following to help the reviewers dive into the pull request.
Explain the context and what changed.

-->

Fixes pyrsia/pyrsia#1229

## Screenshots (optional)

## PR Checklist

<!-- Make certain you've done the following. -->

- [X] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [X] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/community/get_involved/good_pr.md)
- [X] I've included a good title and brief description along with how to review them.
- [X] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).

### Code Contributions

<!--

This section applies to code modifications, you may remove it otherwise.

Make sure your Pull Request will pass the CI/CD pipeline.
For a complete list of steps, check out the [developer PR guidlines](https://github.com/pyrsia/pyrsia/blob/main/docs/community/get_involved/submit_pr.md)!

-->

- [X] I've built the code `cargo build --all-targets` successfully.
- [X] I've run the unit tests `cargo test --workspace` and everything passes.
- [X] I've made sure my rust toolchain is current `rustup update`.
