### PR TITLE
Don't exit Pyrsia node when connecting to other p2p node fails

### DIFF
--- a/pyrsia_node/src/args/parser.rs
+++ b/pyrsia_node/src/args/parser.rs
@@ -27,7 +27,7 @@ const DEFAULT_PORT: &str = "7888";
 const DEFAULT_BOOTSTRAP_URL: &str = "http://boot.pyrsia.link/status";
 
 /// Application to connect to and participate in the Pyrsia network
-#[derive(Debug, Parser)]
+#[derive(Clone, Debug, Parser)]
 #[clap(name = "Pyrsia Node")]
 pub struct PyrsiaNodeArgs {
     /// The host address to bind to for the Docker API


### PR DESCRIPTION
## Description

Fixes pyrsia#1196

This PR makes sure that the Pyrsia node does not exit in case it fails to connect with another Pyrsia node on the p2p network at startup. A warning message is now being logged instead.

## PR Checklist

<!-- Make certain you've done the following. -->

- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/community/get_involved/good_pr.md)
- [x] I've included a good title and brief description along with how to review them.
- [x] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).

### Code Contributions

<!--

This section applies to code modifications, you may remove it otherwise.

Make sure your Pull Request will pass the CI/CD pipeline.
For a complete list of steps, check out the [developer PR guidlines](https://github.com/pyrsia/pyrsia/blob/main/docs/community/get_involved/submit_pr.md)!

-->

- [x] I've built the code `cargo build --all-targets` successfully.
- [x] I've run the unit tests `cargo test --workspace` and everything passes.
- [x] I've made sure my rust toolchain is current `rustup update`.
