### PR TITLE
Have build fail on curl error

### DIFF
--- a/installers/docker/AptGet.Dockerfile
+++ b/installers/docker/AptGet.Dockerfile
@@ -11,7 +11,9 @@ ENV PYRSIA_BOOTDNS=boot.pyrsia.link
 
 RUN apt-get update; \
     apt-get -y install ca-certificates wget gnupg2 jq curl dnsutils; \
-    wget -O - https://pyrsia.io/install.sh | sh; 
+    curl --fail https://pyrsia.io/install.sh -o ./install.sh; \
+    chmod 755 ./install.sh; \
+    ./install.sh; 
 
 # Need to run an entrypoint script that will determine if the docker container
 # is running under Kubernetes or not.  This is done to derive the external ip address


### PR DESCRIPTION
<!--

Thank you for participating with our effort to build a more secure software supply chain.
Before submitting your Pull Request, please go over our check list.

-->

## Description

One-liner for curl command caused image to be built without the pyrsia_node being installed when the curl command failed.  Broke the one-liner into multiple commands so the build will stop on a curl error.

<!--

Try to fill in the following to help the reviewers dive into the pull request.
Explain the context and what changed.

-->

## Screenshots (optional)

## PR Checklist

<!-- Make certain you've done the following. -->

- [X] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [X] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/community/get_involved/good_pr.md)
- [X] I've included a good title and brief description along with how to review them.
- [X] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).

### Code Contributions

<!--

This section applies to code modifications, you may remove it otherwise.

Make sure your Pull Request will pass the CI/CD pipeline.
For a complete list of steps, check out the [developer PR guidlines](https://github.com/pyrsia/pyrsia/blob/main/docs/community/get_involved/submit_pr.md)!

-->

- [X] I've built the code `cargo build --all-targets` successfully.
- [X] I've run the unit tests `cargo test --workspace` and everything passes.
- [X] I've made sure my rust toolchain is current `rustup update`.
