### PR TITLE
Update the install guide for Mac

### DIFF
--- a/docs/tutorials/faq.md
+++ b/docs/tutorials/faq.md
@@ -36,5 +36,5 @@ rd /s c:\Pyrsia\Pyrsia\service\pyrsia
 
 ```shell
 # macOS
-rm -rf /usr/local/var/pyrsia
+rm -rf $(brew --prefix)/var/pyrsia
 ```

--- a/docs/tutorials/faq.md
+++ b/docs/tutorials/faq.md
@@ -36,5 +36,5 @@ rd /s c:\Pyrsia\Pyrsia\service\pyrsia
 
 ```shell
 # macOS
-rm -rf ~/pyrsia
+rm -rf /usr/local/var/pyrsia
 ```

--- a/docs/tutorials/quick-installation.mdx
+++ b/docs/tutorials/quick-installation.mdx
@@ -137,11 +137,11 @@ brew services start pyrsia
 ```
 As per service configuration, Pyrsia Node service logging level set to `info` except module pyrsia set to `dubug`.
 
-When you start the Pyrsia node for the first time, a directory is created in `/usr/local/var/pyrsia/` where all logs and blockchain data are saved. Also macOS might ask for network connection permission. So make sure to allow this.
+When you start the Pyrsia node for the first time, a directory is created in `$(brew --prefix)/var/pyrsia/` where all logs and blockchain data are saved. Also macOS might ask for network connection permission. So make sure to allow this.
 
 - Once Pyrsia node is running state, similar kind of logs can be found in the Homebrew log file.
 ```
- $ tail -f /usr/local/var/pyrsia/logs/stdout/pyrsia_node.log
+ $ tail -f $(brew --prefix)/var/pyrsia/logs/stdout/pyrsia_node.log
  2022-10-20T07:45:57.707Z INFO  pyrsia_node > Pyrsia Node will start running on 0.0.0.0:7888
  2022-10-20T07:45:57.708Z INFO  pyrsia_node > Looking up bootstrap node
  2022-10-20T07:45:57.709Z INFO  pyrsia::network::event_loop > Local node is listening on "/ip4/192.168.86.171/tcp/54690/p2p/12D3KooWL8xbhUABLVUAmpcVoCZSghRX1XZZmoyMPo4VC28CEx6P"

--- a/docs/tutorials/quick-installation.mdx
+++ b/docs/tutorials/quick-installation.mdx
@@ -135,7 +135,7 @@ brew install pyrsia
 ```shell
 brew services start pyrsia
 ```
-This will start Pyrsia node in you local machine with logging level set to `info`. (For additional level of logging, you can also set this to `export RUST_LOG=debug`.)
+As per service configuration, Pyrsia Node service logging level set to `info` except module pyrsia set to `dubug`.
 
 When you start the Pyrsia node for the first time, a directory is created in `/usr/local/var/pyrsia/` where all logs and blockchain data are saved. Also macOS might ask for network connection permission. So make sure to
 allow this.

--- a/docs/tutorials/quick-installation.mdx
+++ b/docs/tutorials/quick-installation.mdx
@@ -137,7 +137,7 @@ brew services start pyrsia
 ```
 This will start Pyrsia node in you local machine with logging level set to `info`. (For additional level of logging, you can also set this to `export RUST_LOG=debug`.)
 
-When you start the Pyrsia node for the first time, a storage directory is created in `/usr/local/var/pyrsia/` where all logs and blockchain data are saved. Also macOS might ask for network connection permission. So make sure to
+When you start the Pyrsia node for the first time, a directory is created in `/usr/local/var/pyrsia/` where all logs and blockchain data are saved. Also macOS might ask for network connection permission. So make sure to
 allow this.
 
 - Once Pyrsia node is running state, similar kind of logs can be found in the Homebrew log file.

--- a/docs/tutorials/quick-installation.mdx
+++ b/docs/tutorials/quick-installation.mdx
@@ -131,7 +131,7 @@ brew tap pyrsia/pyrsia
 ```shell
 brew install pyrsia
 ```
-- Open a terminal and start Pyrsia Node using the following
+- Open a terminal and start Pyrsia Node as background service using the following
 ```shell
 brew services start pyrsia
 ```

--- a/docs/tutorials/quick-installation.mdx
+++ b/docs/tutorials/quick-installation.mdx
@@ -134,17 +134,16 @@ brew install pyrsia
 - Open a terminal and start Pyrsia Node using the following
 ```shell
 export RUST_LOG=info
-cd ~
-pyrsia_node
+brew services start pyrsia
 ```
 This will start Pyrsia node in you local machine with logging level set to `info`. (For additional level of logging, you can also set this to `export RUST_LOG=debug`.)
 
 When you start the Pyrsia node for first time, a directory named pyrsia is created in the current directory. Also macOS might ask for network connection permission. So make sure to
 allow this.
 
-- Once Pyrsia node is running state, the log will display similar kind of logs in the terminal
+- Once Pyrsia node is running state, similar kind of logs can be found in the Homebrew log file.
 ```
- $ pyrsia_node -H 0.0.0.0
+ $ tail -f /usr/local/var/pyrsia/logs/stdout/pyrsia_node.log
  2022-10-20T07:45:57.707Z INFO  pyrsia_node > Pyrsia Docker Node will start running on 0.0.0.0:7888
  2022-10-20T07:45:57.708Z INFO  pyrsia_node > Looking up bootstrap node
  2022-10-20T07:45:57.709Z INFO  pyrsia::network::event_loop > Local node is listening on "/ip4/192.168.86.171/tcp/54690/p2p/12D3KooWL8xbhUABLVUAmpcVoCZSghRX1XZZmoyMPo4VC28CEx6P"

--- a/docs/tutorials/quick-installation.mdx
+++ b/docs/tutorials/quick-installation.mdx
@@ -137,8 +137,7 @@ brew services start pyrsia
 ```
 As per service configuration, Pyrsia Node service logging level set to `info` except module pyrsia set to `dubug`.
 
-When you start the Pyrsia node for the first time, a directory is created in `/usr/local/var/pyrsia/` where all logs and blockchain data are saved. Also macOS might ask for network connection permission. So make sure to
-allow this.
+When you start the Pyrsia node for the first time, a directory is created in `/usr/local/var/pyrsia/` where all logs and blockchain data are saved. Also macOS might ask for network connection permission. So make sure to allow this.
 
 - Once Pyrsia node is running state, similar kind of logs can be found in the Homebrew log file.
 ```

--- a/docs/tutorials/quick-installation.mdx
+++ b/docs/tutorials/quick-installation.mdx
@@ -135,7 +135,7 @@ brew install pyrsia
 ```shell
 brew services start pyrsia
 ```
-As per service configuration, Pyrsia Node service logging level set to `info` except module pyrsia set to `dubug`.
+As per service configuration, Pyrsia Node service logging level set to `info` except module pyrsia set to `debug`.
 
 When you start the Pyrsia node for the first time, a directory is created in `$(brew --prefix)/var/pyrsia/` where all logs and blockchain data are saved. Also macOS might ask for network connection permission. So make sure to allow this.
 

--- a/docs/tutorials/quick-installation.mdx
+++ b/docs/tutorials/quick-installation.mdx
@@ -141,9 +141,9 @@ This will start Pyrsia node in you local machine with logging level set to `info
 When you start the Pyrsia node for first time, a directory named pyrsia is created in the current directory. Also macOS might ask for network connection permission. So make sure to
 allow this.
 
-- Once Pyrsia node is running state, similar kind of logs can be found in the Homebrew log file.
+- Once Pyrsia node is running state, similar kind of logs can be found in the Homebrew log file. (Currently all logs are written in the error log file. It may be updated to be sent forward to )
 ```
- $ tail -f /usr/local/var/pyrsia/logs/stdout/pyrsia_node.log
+ $ tail -f /usr/local/var/pyrsia/logs/stderr/pyrsia_node_err.log
  2022-10-20T07:45:57.707Z INFO  pyrsia_node > Pyrsia Node will start running on 0.0.0.0:7888
  2022-10-20T07:45:57.708Z INFO  pyrsia_node > Looking up bootstrap node
  2022-10-20T07:45:57.709Z INFO  pyrsia::network::event_loop > Local node is listening on "/ip4/192.168.86.171/tcp/54690/p2p/12D3KooWL8xbhUABLVUAmpcVoCZSghRX1XZZmoyMPo4VC28CEx6P"

--- a/docs/tutorials/quick-installation.mdx
+++ b/docs/tutorials/quick-installation.mdx
@@ -133,17 +133,16 @@ brew install pyrsia
 ```
 - Open a terminal and start Pyrsia Node using the following
 ```shell
-export RUST_LOG=info
 brew services start pyrsia
 ```
 This will start Pyrsia node in you local machine with logging level set to `info`. (For additional level of logging, you can also set this to `export RUST_LOG=debug`.)
 
-When you start the Pyrsia node for first time, a directory named pyrsia is created in the current directory. Also macOS might ask for network connection permission. So make sure to
+When you start the Pyrsia node for the first time, a storage directory is created in `/usr/local/var/pyrsia/` where all logs and blockchain data are saved. Also macOS might ask for network connection permission. So make sure to
 allow this.
 
-- Once Pyrsia node is running state, similar kind of logs can be found in the Homebrew log file. (Currently all logs are written in the error log file. It may be updated to be sent forward to )
+- Once Pyrsia node is running state, similar kind of logs can be found in the Homebrew log file.
 ```
- $ tail -f /usr/local/var/pyrsia/logs/stderr/pyrsia_node_err.log
+ $ tail -f /usr/local/var/pyrsia/logs/stdout/pyrsia_node.log
  2022-10-20T07:45:57.707Z INFO  pyrsia_node > Pyrsia Node will start running on 0.0.0.0:7888
  2022-10-20T07:45:57.708Z INFO  pyrsia_node > Looking up bootstrap node
  2022-10-20T07:45:57.709Z INFO  pyrsia::network::event_loop > Local node is listening on "/ip4/192.168.86.171/tcp/54690/p2p/12D3KooWL8xbhUABLVUAmpcVoCZSghRX1XZZmoyMPo4VC28CEx6P"


### PR DESCRIPTION
## Description

Updated documents because the path where Pyrsia stores the data was changed.

### Question

Currently all logs seem to be written in `/usr/local/var/pyrsia/logs/stdout/pyrsia_node.log`, not `/usr/local/var/pyrsia/logs/stdout/pyrsia_node.log`. Is it intentional?
It may be better to update the Homebrew settings to make `log_path` and `error_log_path` same. This happens because all Pyrsia logs are output to the standard error.

The settings of Homebrew formula: [code](https://github.com/pyrsia/homebrew-pyrsia/blob/main/Formula/pyrsia.rb#L42)

## PR Checklist

<!-- Make certain you've done the following. -->

- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/community/get_involved/good_pr.md)
- [x] I've included a good title and brief description along with how to review them.
- [x] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).