### PR TITLE
Updates pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -42,4 +42,3 @@ For a complete list of steps, check out the [developer PR guidlines](https://git
 
 - [ ] I've built the code `cargo build --all-targets` successfully.
 - [ ] I've run the unit tests `cargo test --workspace` and everything passes.
-- [ ] I've made sure my rust toolchain is current `rustup update`.

--- a/docs/tutorials/quick-installation.mdx
+++ b/docs/tutorials/quick-installation.mdx
@@ -145,7 +145,7 @@ allow this.
 - Once Pyrsia node is running state, the log will display similar kind of logs in the terminal
 ```
  $ pyrsia_node -H 0.0.0.0
- 2022-10-20T07:45:57.707Z INFO  pyrsia_node > Pyrsia Docker Node will start running on 0.0.0.0:7888
+ 2022-10-20T07:45:57.707Z INFO  pyrsia_node > Pyrsia Node will start running on 0.0.0.0:7888
  2022-10-20T07:45:57.708Z INFO  pyrsia_node > Looking up bootstrap node
  2022-10-20T07:45:57.709Z INFO  pyrsia::network::event_loop > Local node is listening on "/ip4/192.168.86.171/tcp/54690/p2p/12D3KooWL8xbhUABLVUAmpcVoCZSghRX1XZZmoyMPo4VC28CEx6P"
  2022-10-20T07:45:57.709Z INFO  pyrsia::network::event_loop > Local node is listening on "/ip4/127.0.0.1/tcp/54690/p2p/12D3KooWL8xbhUABLVUAmpcVoCZSghRX1XZZmoyMPo4VC28CEx6P"

--- a/pyrsia_node/src/main.rs
+++ b/pyrsia_node/src/main.rs
@@ -213,7 +213,7 @@ async fn connect_to_p2p_network(
     } else if args.listen_only {
         info!("Pyrsia node will listen only. No attempt to connect to other nodes.");
     } else {
-        info!("Looking up bootstrap node");
+        info!("Looking up bootstrap node: {:?}", &args.bootstrap_url);
         let peer_addrs = load_peer_addrs(&args.bootstrap_url).await?;
         // Turbofish! https://doc.rust-lang.org/std/primitive.str.html#method.parse
         let pa = peer_addrs.parse::<libp2p::Multiaddr>()?;
@@ -397,7 +397,7 @@ fn setup_http(
 ) {
     // Get host and port from the settings. Defaults to DEFAULT_HOST and DEFAULT_PORT
     debug!(
-        "Pyrsia Docker Node will bind to host = {}, port = {}",
+        "Pyrsia Node will bind to host = {}, port = {}",
         args.host, args.port
     );
 
@@ -422,7 +422,7 @@ fn setup_http(
     .bind_ephemeral(address);
 
     info!(
-        "Pyrsia Docker Node will start running on {}:{}",
+        "Pyrsia Node will start running on {}:{}",
         addr.ip(),
         addr.port()
     );


### PR DESCRIPTION
This PR updates the template to not require each PR to run rustup update. This has broken stuff in the past and is agressive in terms of updating rust. Instead we would like to update rust more deliberately and diligently.