### PR TITLE
Return actual build id when requesting build on another node

### DIFF
--- a/pyrsia_node/src/main.rs
+++ b/pyrsia_node/src/main.rs
@@ -127,6 +127,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         package_type, package_specific_id
                     );
                     if let Err(error) = handlers::handle_request_build(
+                        p2p_client.clone(),
                         build_event_client.clone(),
                         package_type,
                         &package_specific_id,
@@ -135,7 +136,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     .await
                     {
                         warn!(
-                            "This node failed to provide build with package type {:?} and id {}. Error: {:?}",
+                            "This node failed to start build with package type {:?} and id {}. Error: {:?}",
                             package_type, package_specific_id, error
                         );
                     }

--- a/src/network/client/command.rs
+++ b/src/network/client/command.rs
@@ -17,6 +17,7 @@
 use crate::artifact_service::model::PackageType;
 use crate::network::artifact_protocol::ArtifactResponse;
 use crate::network::blockchain_protocol::BlockchainResponse;
+use crate::network::build_protocol::BuildResponse;
 use crate::network::idle_metric_protocol::{IdleMetricResponse, PeerMetrics};
 use crate::node_api::model::cli::Status;
 use libp2p::core::{Multiaddr, PeerId};
@@ -63,6 +64,10 @@ pub enum Command {
         package_type: PackageType,
         package_specific_id: String,
         sender: oneshot::Sender<anyhow::Result<String>>,
+    },
+    RespondBuild {
+        build_id: String,
+        channel: ResponseChannel<BuildResponse>,
     },
     RequestArtifact {
         artifact_id: String,


### PR DESCRIPTION
<!--

Thank you for participating with our effort to build a more secure software supply chain.
Before submitting your Pull Request, please go over our check list.

-->

## Description

<!--

Try to fill in the following to help the reviewers dive into the pull request.
Explain the context and what changed.

-->

Fixes pyrsia#1313

This PR returns the actual build ID to the Pyrsia CLI when the build command was used and the actual build was triggered on a different Pyrsia node instead of the local Pyrsia node.

## Steps to test

Follow the procedure described in [Pyrsia demo: build Docker images from source](https://pyrsia.io/docs/developers/build_from_source_docker/). When triggering a build from source from node B (aka the node that was not authorized) using the pyrsia CLI, it should print a UUID instead of a regular number:

> Build request successfully handled. Build with ID 4cffa388-52b1-4f5c-9516-bbdbcfbf49ca has been started.

## PR Checklist

<!-- Make certain you've done the following. -->

- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/community/get_involved/good_pr.md)
- [x] I've included a good title and brief description along with how to review them.
- [x] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).

### Code Contributions

<!--

This section applies to code modifications, you may remove it otherwise.

Make sure your Pull Request will pass the CI/CD pipeline.
For a complete list of steps, check out the [developer PR guidlines](https://github.com/pyrsia/pyrsia/blob/main/docs/community/get_involved/submit_pr.md)!

-->

- [x] I've built the code `cargo build --all-targets` successfully.
- [x] I've run the unit tests `cargo test --workspace` and everything passes.
