### PR TITLE
pin rust to 1.65 and display rust versions

### DIFF
--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: sbtaylor15/rust-toolchain@v1      
+      - uses: pyrsia/rust-toolchain@v1      
       - run: mkdir -p $HOME/.cargo
       - run: cp .github/workflows/.cargo/audit.toml $HOME/.cargo
       - uses: actions-rs/audit-check@v1
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: sbtaylor15/rust-toolchain@v1 
+      - uses: pyrsia/rust-toolchain@v1 
         with:
           components: rustfmt  
       - run: cargo fmt --version
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: sbtaylor15/rust-toolchain@v1 
+      - uses: pyrsia/rust-toolchain@v1 
         with:
           components: clippy                    
       - uses: actions-rs/clippy-check@v1

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -13,8 +13,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Install 1.65 toolchain
+        id: toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.65
+          override: true 
+      - name: Display Rust Version
+        run: |
+          echo "Display Rust Version"
+          echo "rustc: ${{ steps.toolchain.outputs.rustc }}"
+          echo "rustc_hash: ${{ steps.toolchain.outputs.rustc_hash }}"
+          echo "cargo: ${{ steps.toolchain.outputs.cargo }}"
+          echo "rustup: ${{ steps.toolchain.outputs.rustup }}"          
       - run: mkdir -p $HOME/.cargo
-      - run: rustup update && cargo --version
       - run: cp .github/workflows/.cargo/audit.toml $HOME/.cargo
       - uses: actions-rs/audit-check@v1
         with:
@@ -24,7 +36,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: rustup component add rustfmt
+      - name: Install 1.65 toolchain
+        id: toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.65
+          override: true   
+          components: rustfmt  
+      - name: Display Rust Version
+        run: |
+          echo "Display Rust Version"
+          echo "rustc: ${{ steps.toolchain.outputs.rustc }}"
+          echo "rustc_hash: ${{ steps.toolchain.outputs.rustc_hash }}"
+          echo "cargo: ${{ steps.toolchain.outputs.cargo }}"
+          echo "rustup: ${{ steps.toolchain.outputs.rustup }}"                         
       - run: cargo fmt --version
       - run: cargo fmt -- --check # Prints diff in the action logs
 
@@ -37,8 +62,20 @@ jobs:
           version: '3.x'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v3
-      - run: rustup component add clippy
-      - run: cargo clippy --version
+      - name: Install 1.65 toolchain
+        id: toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.65
+          override: true  
+          components: clippy  
+      - name: Display Rust Version
+        run: |
+          echo "Display Rust Version"
+          echo "rustc: ${{ steps.toolchain.outputs.rustc }}"
+          echo "rustc_hash: ${{ steps.toolchain.outputs.rustc_hash }}"
+          echo "cargo: ${{ steps.toolchain.outputs.cargo }}"
+          echo "rustup: ${{ steps.toolchain.outputs.rustup }}"                        
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -7,25 +7,13 @@ on:
       - '**/*.rs'
       - '**/Cargo.toml'
       - Cargo.lock
-      
+
 jobs:
   security-audit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install 1.65 toolchain
-        id: toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.65
-          override: true 
-      - name: Display Rust Version
-        run: |
-          echo "Display Rust Version"
-          echo "rustc: ${{ steps.toolchain.outputs.rustc }}"
-          echo "rustc_hash: ${{ steps.toolchain.outputs.rustc_hash }}"
-          echo "cargo: ${{ steps.toolchain.outputs.cargo }}"
-          echo "rustup: ${{ steps.toolchain.outputs.rustup }}"          
+      - uses: sbtaylor15/rust-toolchain@v1      
       - run: mkdir -p $HOME/.cargo
       - run: cp .github/workflows/.cargo/audit.toml $HOME/.cargo
       - uses: actions-rs/audit-check@v1
@@ -36,46 +24,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install 1.65 toolchain
-        id: toolchain
-        uses: actions-rs/toolchain@v1
+      - uses: sbtaylor15/rust-toolchain@v1 
         with:
-          toolchain: 1.65
-          override: true   
           components: rustfmt  
-      - name: Display Rust Version
-        run: |
-          echo "Display Rust Version"
-          echo "rustc: ${{ steps.toolchain.outputs.rustc }}"
-          echo "rustc_hash: ${{ steps.toolchain.outputs.rustc_hash }}"
-          echo "cargo: ${{ steps.toolchain.outputs.cargo }}"
-          echo "rustup: ${{ steps.toolchain.outputs.rustup }}"                         
       - run: cargo fmt --version
       - run: cargo fmt -- --check # Prints diff in the action logs
 
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          version: '3.x'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v3
-      - name: Install 1.65 toolchain
-        id: toolchain
-        uses: actions-rs/toolchain@v1
+      - uses: sbtaylor15/rust-toolchain@v1 
         with:
-          toolchain: 1.65
-          override: true  
-          components: clippy  
-      - name: Display Rust Version
-        run: |
-          echo "Display Rust Version"
-          echo "rustc: ${{ steps.toolchain.outputs.rustc }}"
-          echo "rustc_hash: ${{ steps.toolchain.outputs.rustc_hash }}"
-          echo "cargo: ${{ steps.toolchain.outputs.cargo }}"
-          echo "rustup: ${{ steps.toolchain.outputs.rustup }}"                        
+          components: clippy                    
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: Rust
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, rust ]
   pull_request:
     paths: # Make sure to keep sync'd https://github.com/pyrsia/pyrsia/blob/main/.github/workflows/rust-skipped.yml#L8
       - .github/workflows/rust.yml

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,21 +30,6 @@ jobs:
     - uses: actions/checkout@v3
     - uses: sbtaylor15/rust-toolchain@v1 
 
-    - name: Install 1.65 toolchain
-      id: toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: 1.65
-        override: true
-
-    - name: Display Rust Version
-      run: |
-        echo "Display Rust Version"
-        echo "rustc: ${{ steps.toolchain.outputs.rustc }}"
-        echo "rustc_hash: ${{ steps.toolchain.outputs.rustc_hash }}"
-        echo "cargo: ${{ steps.toolchain.outputs.cargo }}"
-        echo "rustup: ${{ steps.toolchain.outputs.rustup }}"
-
     # Use sscache store in GitHub cache
     - uses: actions/cache@v3
       with:
@@ -127,22 +112,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: sbtaylor15/rust-toolchain@v1           
-
-      - name: Install 1.65 toolchain
-        id: toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.65
-          override: true
-
-      - name: Display Rust Version
-        run: |
-          echo "Display Rust Version"
-          echo "rustc: ${{ steps.toolchain.outputs.rustc }}"
-          echo "rustc_hash: ${{ steps.toolchain.outputs.rustc_hash }}"
-          echo "cargo: ${{ steps.toolchain.outputs.cargo }}"
-          echo "rustup: ${{ steps.toolchain.outputs.rustup }}"          
-
+       
       # Use sscache store in GitHub cache
       - uses: actions/cache@v3
         with:
@@ -207,21 +177,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: sbtaylor15/rust-toolchain@v1 
-
-    - name: Install 1.65 toolchain
-      id: toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: 1.65
-        override: true
-
-    - name: Display Rust Version
-      run: |
-        echo "Display Rust Version"
-        echo "rustc: ${{ steps.toolchain.outputs.rustc }}"
-        echo "rustc_hash: ${{ steps.toolchain.outputs.rustc_hash }}"
-        echo "cargo: ${{ steps.toolchain.outputs.cargo }}"
-        echo "rustup: ${{ steps.toolchain.outputs.rustup }}"
 
     # Use sscache store in GitHub cache
     - uses: actions/cache@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,6 +30,21 @@ jobs:
     - uses: actions/checkout@v3
     - uses: sbtaylor15/rust-toolchain@v1 
 
+    - name: Install 1.65 toolchain
+      id: toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.65
+        override: true
+
+    - name: Display Rust Version
+      run: |
+        echo "Display Rust Version"
+        echo "rustc: ${{ steps.toolchain.outputs.rustc }}"
+        echo "rustc_hash: ${{ steps.toolchain.outputs.rustc_hash }}"
+        echo "cargo: ${{ steps.toolchain.outputs.cargo }}"
+        echo "rustup: ${{ steps.toolchain.outputs.rustup }}"
+
     # Use sscache store in GitHub cache
     - uses: actions/cache@v3
       with:
@@ -113,6 +128,21 @@ jobs:
       - uses: actions/checkout@v3
       - uses: sbtaylor15/rust-toolchain@v1           
 
+      - name: Install 1.65 toolchain
+        id: toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.65
+          override: true
+
+      - name: Display Rust Version
+        run: |
+          echo "Display Rust Version"
+          echo "rustc: ${{ steps.toolchain.outputs.rustc }}"
+          echo "rustc_hash: ${{ steps.toolchain.outputs.rustc_hash }}"
+          echo "cargo: ${{ steps.toolchain.outputs.cargo }}"
+          echo "rustup: ${{ steps.toolchain.outputs.rustup }}"          
+
       # Use sscache store in GitHub cache
       - uses: actions/cache@v3
         with:
@@ -177,6 +207,21 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: sbtaylor15/rust-toolchain@v1 
+
+    - name: Install 1.65 toolchain
+      id: toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.65
+        override: true
+
+    - name: Display Rust Version
+      run: |
+        echo "Display Rust Version"
+        echo "rustc: ${{ steps.toolchain.outputs.rustc }}"
+        echo "rustc_hash: ${{ steps.toolchain.outputs.rustc_hash }}"
+        echo "cargo: ${{ steps.toolchain.outputs.cargo }}"
+        echo "rustup: ${{ steps.toolchain.outputs.rustup }}"
 
     # Use sscache store in GitHub cache
     - uses: actions/cache@v3
@@ -281,6 +326,14 @@ jobs:
         fetch-depth: 0
 
     - uses: sbtaylor15/rust-toolchain@v1 
+
+    - name: Display Rust Version
+      run: |
+        echo "Display Rust Version"
+        echo "rustc: ${{ steps.toolchain.outputs.rustc }}"
+        echo "rustc_hash: ${{ steps.toolchain.outputs.rustc_hash }}"
+        echo "cargo: ${{ steps.toolchain.outputs.cargo }}"
+        echo "rustup: ${{ steps.toolchain.outputs.rustup }}"
 
     - name: Run cargo-tarpaulin
       uses: actions-rs/tarpaulin@v0.1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,21 +28,7 @@ jobs:
       CARGO_INCREMENTAL: 0
     steps:
     - uses: actions/checkout@v3
-
-    - name: Install 1.65 toolchain
-      id: toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: 1.65
-        override: true
-
-    - name: Display Rust Version
-      run: |
-        echo "Display Rust Version"
-        echo "rustc: ${{ steps.toolchain.outputs.rustc }}"
-        echo "rustc_hash: ${{ steps.toolchain.outputs.rustc_hash }}"
-        echo "cargo: ${{ steps.toolchain.outputs.cargo }}"
-        echo "rustup: ${{ steps.toolchain.outputs.rustup }}"
+    - uses: sbtaylor15/rust-toolchain@v1 
 
     # Use sscache store in GitHub cache
     - uses: actions/cache@v3
@@ -55,13 +41,6 @@ jobs:
         .github/workflows/sccache-macos.sh
         sccache --start-server
         sccache --show-stats
-
-    # Install protoc
-    - name: Install Protoc
-      uses: arduino/setup-protoc@v1
-      with:
-        version: '3.x'
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
 
     # Need to add build number to version number
     - id: add-fqbvn-and-export
@@ -132,21 +111,7 @@ jobs:
       CARGO_INCREMENTAL: 0
     steps:
       - uses: actions/checkout@v3
-
-      - name: Install 1.65 toolchain
-        id: toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.65
-          override: true
-
-      - name: Display Rust Version
-        run: |
-          echo "Display Rust Version"
-          echo "rustc: ${{ steps.toolchain.outputs.rustc }}"
-          echo "rustc_hash: ${{ steps.toolchain.outputs.rustc_hash }}"
-          echo "cargo: ${{ steps.toolchain.outputs.cargo }}"
-          echo "rustup: ${{ steps.toolchain.outputs.rustup }}"          
+      - uses: sbtaylor15/rust-toolchain@v1           
 
       # Use sscache store in GitHub cache
       - uses: actions/cache@v3
@@ -160,13 +125,6 @@ jobs:
           .github/workflows/sccache-windows.bat
           sccache --start-server
           sccache --show-stats
-
-      # Install protoc
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          version: '3.x'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Need to add build number to version number
       - name: Add Build to Version Number
@@ -218,21 +176,7 @@ jobs:
       CARGO_INCREMENTAL: 0
     steps:
     - uses: actions/checkout@v3
-
-    - name: Install 1.65 toolchain
-      id: toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: 1.65
-        override: true
-
-    - name: Display Rust Version
-      run: |
-        echo "Display Rust Version"
-        echo "rustc: ${{ steps.toolchain.outputs.rustc }}"
-        echo "rustc_hash: ${{ steps.toolchain.outputs.rustc_hash }}"
-        echo "cargo: ${{ steps.toolchain.outputs.cargo }}"
-        echo "rustup: ${{ steps.toolchain.outputs.rustup }}"
+    - uses: sbtaylor15/rust-toolchain@v1 
 
     # Use sscache store in GitHub cache
     - uses: actions/cache@v3
@@ -245,13 +189,6 @@ jobs:
         .github/workflows/sccache-linux.sh
         sccache --start-server
         sccache --show-stats
-
-    # Install protoc
-    - name: Install Protoc
-      uses: arduino/setup-protoc@v1
-      with:
-        version: '3.x'
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
 
     # Need to add build number to version number
     - name: Add Build to Version Number
@@ -343,26 +280,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Install Protoc
-      uses: arduino/setup-protoc@v1
-      with:
-        version: '3.x'
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Install 1.65 toolchain
-      id: toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: 1.65
-        override: true
-
-    - name: Display Rust Version
-      run: |
-        echo "Display Rust Version"
-        echo "rustc: ${{ steps.toolchain.outputs.rustc }}"
-        echo "rustc_hash: ${{ steps.toolchain.outputs.rustc_hash }}"
-        echo "cargo: ${{ steps.toolchain.outputs.cargo }}"
-        echo "rustup: ${{ steps.toolchain.outputs.rustup }}"
+    - uses: sbtaylor15/rust-toolchain@v1 
 
     - name: Run cargo-tarpaulin
       uses: actions-rs/tarpaulin@v0.1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: Rust
 
 on:
   push:
-    branches: [ main, rust ]
+    branches: [ main ]
   pull_request:
     paths: # Make sure to keep sync'd https://github.com/pyrsia/pyrsia/blob/main/.github/workflows/rust-skipped.yml#L8
       - .github/workflows/rust.yml

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,6 +29,21 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Install 1.65 toolchain
+      id: toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.65
+        override: true
+
+    - name: Display Rust Version
+      run: |
+        echo "Display Rust Version"
+        echo "rustc: ${{ steps.toolchain.outputs.rustc }}"
+        echo "rustc_hash: ${{ steps.toolchain.outputs.rustc_hash }}"
+        echo "cargo: ${{ steps.toolchain.outputs.cargo }}"
+        echo "rustup: ${{ steps.toolchain.outputs.rustup }}"
+
     # Use sscache store in GitHub cache
     - uses: actions/cache@v3
       with:
@@ -118,6 +133,21 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Install 1.65 toolchain
+        id: toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.65
+          override: true
+
+      - name: Display Rust Version
+        run: |
+          echo "Display Rust Version"
+          echo "rustc: ${{ steps.toolchain.outputs.rustc }}"
+          echo "rustc_hash: ${{ steps.toolchain.outputs.rustc_hash }}"
+          echo "cargo: ${{ steps.toolchain.outputs.cargo }}"
+          echo "rustup: ${{ steps.toolchain.outputs.rustup }}"          
+
       # Use sscache store in GitHub cache
       - uses: actions/cache@v3
         with:
@@ -189,6 +219,21 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Install 1.65 toolchain
+      id: toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.65
+        override: true
+
+    - name: Display Rust Version
+      run: |
+        echo "Display Rust Version"
+        echo "rustc: ${{ steps.toolchain.outputs.rustc }}"
+        echo "rustc_hash: ${{ steps.toolchain.outputs.rustc_hash }}"
+        echo "cargo: ${{ steps.toolchain.outputs.cargo }}"
+        echo "rustup: ${{ steps.toolchain.outputs.rustup }}"
+
     # Use sscache store in GitHub cache
     - uses: actions/cache@v3
       with:
@@ -223,19 +268,13 @@ jobs:
       run: |
         cargo test --workspace --verbose --release
 
-    # Install cargo deb and strip
-    - name: Install cargo-deb cargo-strip
+    # Install cargo deb
+    - name: Install cargo-deb
       if: github.repository_owner == 'pyrsia' && (github.event_name == 'push' || github.event_name == 'release')
       uses: actions-rs/cargo@v1.0.3
       with:
         command: install
-        args: cargo-deb cargo-strip --force
-
-    # Strip binaries
-    - name: Strip Binaries
-      if: github.repository_owner == 'pyrsia' && (github.event_name == 'push' || github.event_name == 'release')
-      run: |
-        cargo strip
+        args: cargo-deb --force
 
     # Create Pyrsia .deb file
     - name: Package Pyrsia as deb file
@@ -310,11 +349,20 @@ jobs:
         version: '3.x'
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Install stable toolchain
+    - name: Install 1.65 toolchain
+      id: toolchain
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.65
         override: true
+
+    - name: Display Rust Version
+      run: |
+        echo "Display Rust Version"
+        echo "rustc: ${{ steps.toolchain.outputs.rustc }}"
+        echo "rustc_hash: ${{ steps.toolchain.outputs.rustc_hash }}"
+        echo "cargo: ${{ steps.toolchain.outputs.cargo }}"
+        echo "rustup: ${{ steps.toolchain.outputs.rustup }}"
 
     - name: Run cargo-tarpaulin
       uses: actions-rs/tarpaulin@v0.1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,7 @@ jobs:
       CARGO_INCREMENTAL: 0
     steps:
     - uses: actions/checkout@v3
-    - uses: sbtaylor15/rust-toolchain@v1 
+    - uses: pyrsia/rust-toolchain@v1 
 
     # Use sscache store in GitHub cache
     - uses: actions/cache@v3
@@ -111,7 +111,7 @@ jobs:
       CARGO_INCREMENTAL: 0
     steps:
       - uses: actions/checkout@v3
-      - uses: sbtaylor15/rust-toolchain@v1           
+      - uses: pyrsia/rust-toolchain@v1           
        
       # Use sscache store in GitHub cache
       - uses: actions/cache@v3
@@ -176,7 +176,7 @@ jobs:
       CARGO_INCREMENTAL: 0
     steps:
     - uses: actions/checkout@v3
-    - uses: sbtaylor15/rust-toolchain@v1 
+    - uses: pyrsia/rust-toolchain@v1 
 
     # Use sscache store in GitHub cache
     - uses: actions/cache@v3
@@ -280,15 +280,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - uses: sbtaylor15/rust-toolchain@v1 
-
-    - name: Display Rust Version
-      run: |
-        echo "Display Rust Version"
-        echo "rustc: ${{ steps.toolchain.outputs.rustc }}"
-        echo "rustc_hash: ${{ steps.toolchain.outputs.rustc_hash }}"
-        echo "cargo: ${{ steps.toolchain.outputs.cargo }}"
-        echo "rustup: ${{ steps.toolchain.outputs.rustup }}"
+    - uses: pyrsia/rust-toolchain@v1 
 
     - name: Run cargo-tarpaulin
       uses: actions-rs/tarpaulin@v0.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "Pyrsia Node and CLI"
 authors = ["pyrsiaoss <pyrsiaopensource@gmail.com>"]
 license = "Apache-2"
 repository = "https://github.com/pyrsia/pyrsia"
-rust = "1.65"
+rust = "1.64"
 
 [package.metadata.deb]
 assets = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ description = "Pyrsia Node and CLI"
 authors = ["pyrsiaoss <pyrsiaopensource@gmail.com>"]
 license = "Apache-2"
 repository = "https://github.com/pyrsia/pyrsia"
+rust = "1.65"
 
 [package.metadata.deb]
 assets = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,3 +113,4 @@ panic = 'unwind'
 incremental = false
 codegen-units = 16
 rpath = false
+strip = true


### PR DESCRIPTION
<!--

Thank you for participating with our effort to build a more secure software supply chain.
Before submitting your Pull Request, please go over our check list.

-->

## Description

Explicitly set the tool chain version to 1.65.  Added a steps to display the rust versions to the log output.  Moved `strip` from a separate step to be part of the Release Profile in the config.toml so all OS perform strip as part of a Release Build in the GH Actions.

<!--

Try to fill in the following to help the reviewers dive into the pull request.
Explain the context and what changed.

-->

Fixes pyrsia/pyrsia#1352

## Screenshots (optional)

## PR Checklist

<!-- Make certain you've done the following. -->

- [X] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [X] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/community/get_involved/good_pr.md)
- [X] I've included a good title and brief description along with how to review them.
- [X] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).

### Code Contributions

<!--

This section applies to code modifications, you may remove it otherwise.

Make sure your Pull Request will pass the CI/CD pipeline.
For a complete list of steps, check out the [developer PR guidlines](https://github.com/pyrsia/pyrsia/blob/main/docs/community/get_involved/submit_pr.md)!

-->

- [X] I've built the code `cargo build --all-targets` successfully.
- [X] I've run the unit tests `cargo test --workspace` and everything passes.
