### PR TITLE
Return useful error messages in the Pyrsia CLI

### DIFF
--- a/pyrsia_cli/src/cli/handlers.rs
+++ b/pyrsia_cli/src/cli/handlers.rs
@@ -151,7 +151,7 @@ pub async fn request_maven_build(gav: &str) {
         gav: gav.to_owned(),
     })
     .await;
-    // handle_request_build_result(build_result);
+    handle_request_build_result(build_result);
 }
 
 fn handle_request_build_result(build_result: Result<String, Error>) {

--- a/pyrsia_cli/src/cli/handlers.rs
+++ b/pyrsia_cli/src/cli/handlers.rs
@@ -162,8 +162,8 @@ fn handle_request_build_result(build_result: Result<String, Error>) {
                 build_id
             );
         }
-        Err(error) => {
-            println!("Build request failed with error: {}", error);
+        Err(error_message) => {
+            println!("Build request failed with error: {}", error_message);
         }
     }
 }

--- a/pyrsia_cli/src/cli/handlers.rs
+++ b/pyrsia_cli/src/cli/handlers.rs
@@ -154,7 +154,7 @@ pub async fn request_maven_build(gav: &str) {
     handle_request_build_result(build_result);
 }
 
-fn handle_request_build_result(build_result: Result<String, Error>) {
+fn handle_request_build_result(build_result: Result<String, anyhow::Error>) {
     match build_result {
         Ok(build_id) => {
             println!(

--- a/pyrsia_cli/src/cli/handlers.rs
+++ b/pyrsia_cli/src/cli/handlers.rs
@@ -151,10 +151,10 @@ pub async fn request_maven_build(gav: &str) {
         gav: gav.to_owned(),
     })
     .await;
-    handle_request_build_result(build_result);
+    // handle_request_build_result(build_result);
 }
 
-fn handle_request_build_result(build_result: Result<String, reqwest::Error>) {
+fn handle_request_build_result(build_result: Result<String, Error>) {
     match build_result {
         Ok(build_id) => {
             println!(

--- a/src/artifact_service/service.rs
+++ b/src/artifact_service/service.rs
@@ -104,7 +104,7 @@ impl ArtifactService {
         // prevent duplicated builds
         self.transparency_log_service
             .verify_package_can_be_added_to_transparency_logs(&package_type, &package_specific_id)
-            .map_err(|t| BuildError::ArtifactAlreadyExists(format!("{:?}", t)))?;
+            .map_err(|t| BuildError::ArtifactAlreadyExists(t.to_string()))?;
 
         if local_peer_id.eq(&peer_id) {
             debug!("Start local build in authorized node");

--- a/src/cli_commands/node.rs
+++ b/src/cli_commands/node.rs
@@ -15,8 +15,8 @@
 */
 
 use anyhow::anyhow;
-use reqwest::Response;
 use async_trait::async_trait;
+use reqwest::Response;
 use serde_json::Value;
 
 use crate::node_api::model::cli::{
@@ -61,7 +61,8 @@ pub async fn add_authorized_node(request: RequestAddAuthorizedNode) -> Result<()
 pub async fn request_docker_build(request: RequestDockerBuild) -> Result<String, anyhow::Error> {
     let node_url = format!("http://{}/build/docker", get_url());
     let client = reqwest::Client::new();
-    client.post(&node_url)
+    client
+        .post(&node_url)
         .json(&request)
         .send()
         .await?
@@ -69,19 +70,16 @@ pub async fn request_docker_build(request: RequestDockerBuild) -> Result<String,
         .await
 }
 
-pub async fn request_maven_build(request: RequestMavenBuild) -> Result<String, reqwest::Error> {
+pub async fn request_maven_build(request: RequestMavenBuild) -> Result<String, anyhow::Error> {
     let node_url = format!("http://{}/build/maven", get_url());
     let client = reqwest::Client::new();
-    match client
+    client
         .post(node_url)
         .json(&request)
         .send()
         .await?
-        .error_for_status()
-    {
-        Ok(response) => response.json::<String>().await,
-        Err(e) => Err(e),
-    }
+        .error_for_status_with_body()
+        .await
 }
 
 pub async fn inspect_docker_transparency_log(

--- a/src/docker/error_util.rs
+++ b/src/docker/error_util.rs
@@ -322,6 +322,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn custom_recover_from_registry_error_bad_request() {
+        let registry_error = RegistryError {
+            code: RegistryErrorCode::BadRequest(String::from("bad_request")),
+        };
+
+        let expected_body = serde_json::to_string(&ErrorMessages {
+            errors: vec![ErrorMessage {
+                code: RegistryErrorCode::BadRequest("bad_request".to_string()),
+                message: String::from("bad_request"),
+            }],
+        })
+        .expect("Generating JSON body should not fail.");
+
+        let response = custom_recover(registry_error.into())
+            .await
+            .expect("Reply should be created.")
+            .into_response();
+
+        verify_recover_response(response, expected_body, StatusCode::BAD_REQUEST).await;
+    }
+
+    #[tokio::test]
     async fn custom_recover_from_registry_error_for_unknown() {
         let registry_error = RegistryError {
             code: RegistryErrorCode::Unknown(String::from("unknown_error")),

--- a/src/docker/error_util.rs
+++ b/src/docker/error_util.rs
@@ -157,6 +157,7 @@ pub async fn custom_recover(err: Rejection) -> Result<impl Reply, Infallible> {
             RegistryErrorCode::BadRequest(m) => {
                 status_code = StatusCode::BAD_REQUEST;
                 error_message.code = RegistryErrorCode::BadRequest(m.clone());
+                error_message.message = m.clone();
             }
             RegistryErrorCode::Unknown(m) => {
                 error_message.message = m.clone();


### PR DESCRIPTION
## Description

Part of pyrsia/pyrsia#1221, but this PR does not fix everything.
After this PR is merged, the same change should be applied to all errors.

Details of this change are written in comments below.

## The current response
```
$ pyrsia build docker --image "alpine:3.16"                                                                                                                                          
Build request failed with error: HTTP status client error (400 Bad Request) for url (http://localhost:7888/build/docker)
```

## After this change
```
$ pyrsia build docker --image "alpine:3.16"                                                                                                                           
Build request failed with error: HTTP status error (400 Bad Request) for url (http://localhost:7888/build/docker): "Failed to start a build: Artifact ID alpine:3.16 for type Docker already exists in transparency log"
```

## PR Checklist

<!-- Make certain you've done the following. -->

- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/community/get_involved/good_pr.md)
- [x] I've included a good title and brief description along with how to review them.
- [x] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).

### Code Contributions

- [x] I've built the code `cargo build --all-targets` successfully.
- [x] I've run the unit tests `cargo test --workspace` and everything passes.
