### PR TITLE
The Clippy "large_enum_variant" warnings fix

### DIFF
--- a/src/network/behaviour.rs
+++ b/src/network/behaviour.rs
@@ -56,7 +56,7 @@ pub struct PyrsiaNetworkBehaviour {
 pub enum PyrsiaNetworkEvent {
     AutoNat(autonat::Event),
     Identify(Box<identify::Event>),
-    Kademlia(KademliaEvent),
+    Kademlia(Box<KademliaEvent>),
     RequestResponse(RequestResponseEvent<ArtifactRequest, ArtifactResponse>),
     BuildRequestResponse(RequestResponseEvent<BuildRequest, BuildResponse>),
     IdleMetricRequestResponse(RequestResponseEvent<IdleMetricRequest, IdleMetricResponse>),
@@ -77,7 +77,7 @@ impl From<identify::Event> for PyrsiaNetworkEvent {
 
 impl From<KademliaEvent> for PyrsiaNetworkEvent {
     fn from(event: KademliaEvent) -> Self {
-        PyrsiaNetworkEvent::Kademlia(event)
+        PyrsiaNetworkEvent::Kademlia(Box::new(event))
     }
 }
 

--- a/src/network/event_loop.rs
+++ b/src/network/event_loop.rs
@@ -94,7 +94,7 @@ impl PyrsiaEventLoop {
                 event = self.swarm.select_next_some() => match event {
                     SwarmEvent::Behaviour(PyrsiaNetworkEvent::AutoNat(autonat_event)) => self.handle_autonat_event(autonat_event).await,
                     SwarmEvent::Behaviour(PyrsiaNetworkEvent::Identify(identify_event)) => self.handle_identify_event(*identify_event).await,
-                    SwarmEvent::Behaviour(PyrsiaNetworkEvent::Kademlia(kademlia_event)) => self.handle_kademlia_event(kademlia_event).await,
+                    SwarmEvent::Behaviour(PyrsiaNetworkEvent::Kademlia(kademlia_event)) => self.handle_kademlia_event(*kademlia_event).await,
                     SwarmEvent::Behaviour(PyrsiaNetworkEvent::RequestResponse(request_response_event)) => self.handle_request_response_event(request_response_event).await,
                     SwarmEvent::Behaviour(PyrsiaNetworkEvent::BuildRequestResponse(build_request_response_event)) => self.handle_build_request_response_event(build_request_response_event).await,
                     SwarmEvent::Behaviour(PyrsiaNetworkEvent::IdleMetricRequestResponse(request_response_event)) => self.handle_idle_metric_request_response_event(request_response_event).await,


### PR DESCRIPTION
This change fixes the clippy warning related "large enum variant", the fix boxes KademliaEvent and updates the relevant code accordingly.

<!--

Thank you for participating with our effort to build a more secure software supply chain.
Before submitting your Pull Request, please go over our check list.

-->

## Description

<!--

Try to fill in the following to help the reviewers dive into the pull request.
Explain the context and what changed.

-->

Fixes pyrsia/pyrsia#

This PR does... by accomplishing... and it can be reviewed by... you can also test the changes by running...

## Screenshots (optional)

## PR Checklist

<!-- Make certain you've done the following. -->

- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/community/get_involved/good_pr.md)
- [x] I've included a good title and brief description along with how to review them.
- [x] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).

### Code Contributions

<!--

This section applies to code modifications, you may remove it otherwise.

Make sure your Pull Request will pass the CI/CD pipeline.
For a complete list of steps, check out the [developer PR guidlines](https://github.com/pyrsia/pyrsia/blob/main/docs/community/get_involved/submit_pr.md)!

-->

- [x] I've built the code `cargo build --all-targets` successfully.
- [x] I've run the unit tests `cargo test --workspace` and everything passes.
