### PR TITLE
Fixed a CLI display issue - Remove duplicated quotations

### DIFF
--- a/docs/developers/build_from_source_docker.md
+++ b/docs/developers/build_from_source_docker.md
@@ -240,7 +240,7 @@ Then trigger the build from source, like this:
 The build trigger should return immediately providing a build ID:
 
 ```text
-Build request successfully handled. Build with ID "c9ca3e57-aa84-4fab-a8be-381ab31e4916" has been started.
+Build request successfully handled. Build with ID 'c9ca3e57-aa84-4fab-a8be-381ab31e4916' has been started.
 ```
 
 ## Wait for the build to finish in the build pipeline

--- a/docs/developers/build_from_source_maven.md
+++ b/docs/developers/build_from_source_maven.md
@@ -205,7 +205,7 @@ Then trigger the build from source, like this:
 The build trigger should return immediately providing a build ID:
 
 ```text
-Build request successfully handled. Build with ID "13abff76-5aea-4d05-8f42-d625943ceb78" has been started.
+Build request successfully handled. Build with ID '13abff76-5aea-4d05-8f42-d625943ceb78' has been started.
 ```
 
 ## Wait for the build to finish in the build pipeline

--- a/pyrsia_cli/src/cli/handlers.rs
+++ b/pyrsia_cli/src/cli/handlers.rs
@@ -143,7 +143,7 @@ fn handle_request_build_result(build_result: Result<String, anyhow::Error>) {
     match build_result {
         Ok(build_id) => {
             println!(
-                "Build request successfully handled. Build with ID {} has been started.",
+                "Build request successfully handled. Build with ID '{}' has been started.",
                 build_id
             );
         }


### PR DESCRIPTION
**Please review integration tests update, too.** There is just a small change.
https://github.com/pyrsia/pyrsia-integration-tests/pull/32

For this change, tests are covered by integration tests.

## Description

Fixed a display issue like this. `SUCCESS` is wrapped with single quotes and double quotes so removed double quotes inside. 

```
Build status for '2ddc2c77-b95b-481c-bde1-2d480bd321aa' is '"SUCCESS"'
```

⬇️ 

```
Build status for '2ddc2c77-b95b-481c-bde1-2d480bd321aa' is 'SUCCESS'
```

Also,

- Removed unnecessary definitions of return value types.
- Unified CLI messages. Both single quotes and double quotes were used, but only single quotes would be used.

## PR Checklist

- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/community/get_involved/good_pr.md)
- [x] I've included a good title and brief description along with how to review them.
- [x] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).

### Code Contributions

- [x] I've run [pre-commit.sh](https://github.com/pyrsia/pyrsia/blob/main/pre-commit.sh) ([pre-commit.bat](https://github.com/pyrsia/pyrsia/blob/main/pre-commit.bat)) successfully.
- [x] I've run the [integrations tests](https://github.com/pyrsia/pyrsia-integration-tests#how-to-set-up-and-run-the-tests)
on the PR branch and all tests passes.

-> Created a PR for integration tests.