### PR TITLE
Initiate kademlia bootstrap after probe or dial

### DIFF
--- a/src/network/client/command.rs
+++ b/src/network/client/command.rs
@@ -37,6 +37,9 @@ pub enum Command {
         probe_addr: Multiaddr,
         sender: oneshot::Sender<anyhow::Result<()>>,
     },
+    BootstrapDht {
+        sender: oneshot::Sender<anyhow::Result<()>>,
+    },
     Listen {
         addr: Multiaddr,
         sender: oneshot::Sender<anyhow::Result<()>>,


### PR DESCRIPTION
## Description

Fixes pyrsia#1446

This PR initiates the Kademlia DHT bootstrap after the first address of the boot node was added. In practice, this means that the bootstrap is started when either:

* a dial to another node has finished successfully
* another node was successfully added as the probe address for autonat

## PR Checklist

<!-- Make certain you've done the following. -->

- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/community/get_involved/good_pr.md)
- [x] I've included a good title and brief description along with how to review them.
- [x] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).

### Code Contributions

<!--

This section applies to code modifications, you may remove it otherwise.

Make sure your Pull Request will pass the CI/CD pipeline.
For a complete list of steps, check out the [developer PR guidlines](https://github.com/pyrsia/pyrsia/blob/main/docs/community/get_involved/submit_pr.md)!

-->

- [x] I've run [pre-commit.sh](https://github.com/pyrsia/pyrsia/blob/main/pre-commit.sh) ([pre-commit.bat](https://github.com/pyrsia/pyrsia/blob/main/pre-commit.bat)) successfully.
- [x] I've run the [integrations tests](https://github.com/pyrsia/pyrsia-integration-tests#how-to-set-up-and-run-the-tests)
on the PR branch and all tests passes.
