### PR TITLE
Explicitly remove openssl before build if it is cached. Added dump of…

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -14,6 +14,9 @@
 
 set -e
 
+# Explicitly remove OpenSSL before build in case it is cached
+cargo remove openssl
+
 # We need to split out build commands into separate calls in order to run them in parallel
 # therefore we cannot use --all-targets since that is equivalent to --lib --bins --tests --benches --examples
 # which disables the parallelizm we are trying achive for speed. 
@@ -40,7 +43,8 @@ echo "### Tests Build RC=$(cat /tmp/tests.rc)"
 
 # Check if OpenSSL is back
 if [[ $(find . -name "Cargo.lock" -exec grep -i openssl {} \; | wc -l) != 0 ]]; then
-    echo "OpenSSL Presence detected in the Cargo; please remove it and rebuild."
+    echo "OpenSSL Presence detected in the Cargo; please remove it and rebuild. Dumping Cargo.lock files to log."
+    find . -name "Cargo.lock" -exec cat {} \;
     exit 1
 fi
 


### PR DESCRIPTION
… cargo.lock if openssl is back.

<!--

Thank you for participating with our effort to build a more secure software supply chain.
Before submitting your Pull Request, please go over our check list.

-->

## Description

<!--

Try to fill in the following to help the reviewers dive into the pull request.
Explain the context and what changed.

-->

Fixes pyrsia/pyrsia#1427

This PR adds an explicit removal of openssl if it is already cached in the cargo.lock and then it also dumps the cargo.lock if openssl is detected after the build.

## Screenshots (optional)

## PR Checklist

<!-- Make certain you've done the following. -->

- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/community/get_involved/good_pr.md)
- [x] I've included a good title and brief description along with how to review them.
- [x] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).
