### PR TITLE
Change the order of pages and edit Readme of Contributor docs

### DIFF
--- a/docs/developers/postrelease_manual_tests.md
+++ b/docs/developers/postrelease_manual_tests.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 6
+---
+
 # Post-release manual tests
 
 After a release has been deployed, run these manual tests to make sure everything works as expected. Run these tests after each deployment to

--- a/docs/developers/prerelease_manual_tests.md
+++ b/docs/developers/prerelease_manual_tests.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 5
+---
+
 # Pre-release checks
 
 Before a release, make sure to

--- a/docs/developers/pyrsia-autonat.md
+++ b/docs/developers/pyrsia-autonat.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 3
 ---
 
 # Pyrsia AutoNAT Implementation (IETF STUN)

--- a/docs/developers/readme.md
+++ b/docs/developers/readme.md
@@ -4,8 +4,19 @@ sidebar_position: 3
 
 # Contributor documentation
 
+## Know Pyrsia overview and details
+
 - [Architecture and use cases](/docs/developers/pyrsia-architecture-and-use-cases.md)
 - [Pyrsia demo: build Docker images from source](/docs/developers/build_from_source_docker.md)
+
+## Build, run and test Pyrsia for development
+
 - [Pyrsia demo: build Maven images from source](/docs/developers/build_from_source_maven.md)
 - [Pyrsia AutoNAT Implementation](/docs/developers/pyrsia-autonat.md)
 - [How to start and debug Pyrsia Node using IDE](/docs/developers/setting_up_ide.md)
+
+## Release a new version
+
+- [Pre-release checks](/docs/developers/prerelease_manual_tests.md)
+- [Creating a Release for Pyrsia](/docs/developers/release_process.md)
+- [Post-release manual tests](/docs/developers/postrelease_manual_tests.md)

--- a/docs/developers/release_process.md
+++ b/docs/developers/release_process.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 6
+---
+
 # Creating a Release for Pyrsia
 
 Once the team decides to tag a release please use the following steps to ensure all parts of the service are updated.

--- a/docs/developers/setting_up_ide.md
+++ b/docs/developers/setting_up_ide.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 4
 ---
 
 # How to start and debug Pyrsia Node using IDE


### PR DESCRIPTION
Arranged the contributor documents to make it easier to read.

Changed the order and Categorized the pages in readme.

## Screenshots (optional)

<img width="1774" alt="Screenshot_0005-01-04_at_17_38_08" src="https://user-images.githubusercontent.com/8938191/210682135-2ffea7aa-63c3-4ca4-988f-14f39da0410b.png">

## PR Checklist

- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/community/get_involved/good_pr.md)
- [x] I've included a good title and brief description along with how to review them.
- [x] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).
