### PR TITLE
Rename variables to placeholdersync

### DIFF
--- a/.github/workflows/chartmuseum.sh
+++ b/.github/workflows/chartmuseum.sh
@@ -22,7 +22,7 @@ cd ../..
 
 python3 $WORKSPACE/.github/workflows/genlistingsyncoptimized.py ${listing} gs://helmrepo/repos repos
 # Generate pretty directory listing web pages
-python3 $WORKSPACE/.github/workflows/genlisting.py -r -d
+python3 $WORKSPACE/.github/workflows/genlisting.py -r -p
 
 # copy new public repo to GCS. Excluding all *.tgz files from sync back
 gsutil -m rsync -r -x ".*\.tgz$" repos gs://helmrepo/repos

--- a/.github/workflows/genlisting.py
+++ b/.github/workflows/genlisting.py
@@ -362,7 +362,7 @@ def process_dir(top_dir, opts):
         last_modified_iso = ''
         try:
             if entry.is_file():
-                size_bytes = read_file_size(entry, opts.dummysync)
+                size_bytes = read_file_size(entry, opts.placeholdersync)
                 size_pretty = pretty_size(size_bytes)
 
             if entry.is_dir() or entry.is_file():
@@ -448,8 +448,8 @@ def pretty_size(bytes, units=UNITS_MAPPING):
             suffix = multiple
     return str(amount) + suffix
 
-def read_file_size(entry: Path, dummysync: bool) -> int:
-    if dummysync:
+def read_file_size(entry: Path, placeholdersync: bool) -> int:
+    if placeholdersync:
         try:
             if entry.read_text().startswith("file_size===="):
                 return int(entry.read_text().split("file_size====")[1])
@@ -495,7 +495,7 @@ if __name__ == "__main__":
                              ' verbosely list every processed file',
                         required=False)
 
-    parser.add_argument('--dummysync', '-d',
+    parser.add_argument('--placeholdersync', '-p',
                         action='store_true',
                         help="program assumes instead of rsync, directory and files hierarchy got created "
                              "synthetically from dir/file listing command (FALSE by default)",

--- a/.github/workflows/homebrew-installer-upload.sh
+++ b/.github/workflows/homebrew-installer-upload.sh
@@ -29,6 +29,6 @@ mkdir -p syncdir
 gsutil -m cp pyrsia-${FQBVN}.tar.gz  gs://homebrewrepo/${RELTYPE}/${ARCHTYPE}/pyrsia-${FQBVN}.tar.gz
 listing="$(gsutil ls -lr gs://homebrewrepo)"
 python3 .github/workflows/genlistingsyncoptimized.py ${listing} gs://homebrewrepo syncdir
-python3 .github/workflows/genlisting.py syncdir -r -d
+python3 .github/workflows/genlisting.py syncdir -r -p
 # sync back directory to Cloud Bucket excluding all .*.tar.gz files
 gsutil -m -o "GSUtil:parallel_process_count=1" rsync -r -x ".*\.tar\.gz$" syncdir gs://homebrewrepo


### PR DESCRIPTION
Rename variables in GH Actions scripts to `placeholdersync` based on the linting error.

## PR Checklist

- [x] I've read the [contributing guidelines](https://github.com/pyrsia/.github/blob/main/contributing.md).
- [x] I've read ["What is a Good PR?"](https://github.com/pyrsia/pyrsia/blob/main/docs/community/get_involved/good_pr.md)
- [x] I've included a good title and brief description along with how to review them.
- [x] I've linked any associated an [issue](https://github.com/pyrsia/pyrsia/issues).