### PR TITLE
Prototype of integration testing based on `testcontainers`

### DIFF
--- a/.github/workflows/.cargo/audit.toml
+++ b/.github/workflows/.cargo/audit.toml
@@ -2,4 +2,4 @@
 # A good example is at https://docs.rs/crate/cargo-audit/0.10.0/source/audit.toml.example
 
 [advisories]
-ignore = ["RUSTSEC-2022-0040"] # advisory IDs to ignore
+ignore = ["RUSTSEC-2022-0040", "RUSTSEC-2020-0071"] # advisory IDs to ignore

--- a/.github/workflows/.cargo/audit.toml
+++ b/.github/workflows/.cargo/audit.toml
@@ -2,4 +2,7 @@
 # A good example is at https://docs.rs/crate/cargo-audit/0.10.0/source/audit.toml.example
 
 [advisories]
-ignore = ["RUSTSEC-2022-0040", "RUSTSEC-2020-0071"] # advisory IDs to ignore
+ignore = [
+    "RUSTSEC-2022-0040",
+    "RUSTSEC-2020-0071", # `time` localtime_r segfault
+]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,6 +62,9 @@ jobs:
           sccache --show-stats
 
       # Build docker image to use in integration tests
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Build and Push Docker Image for Pyrsia Node
         uses: docker/build-push-action@v4
         with:
@@ -237,6 +240,9 @@ jobs:
           sccache --show-stats
 
       # Build docker image to use in integration tests
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Build and Push Docker Image for Pyrsia Node
         uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -299,7 +299,7 @@ jobs:
           context: .
           push: false
           file: ./Dockerfile
-          tags: pyrsia/test_node
+          tags: pyrsia/test_node:latest
           build-args: |
             GIT_REPO=${{ github.repository }}
             GIT_COMMIT=${{ github.sha }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -236,6 +236,20 @@ jobs:
           .github/workflows/build.sh
           sccache --show-stats
 
+      # Build docker image to use in integration tests
+      - name: Build and Push Docker Image for Pyrsia Node
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: false
+          file: ./Dockerfile
+          tags: pyrsia/test-node:latest
+          build-args: |
+            GIT_REPO=${{ github.repository }}
+            GIT_COMMIT=${{ github.sha }}
+            GIT_BRANCH=${{ github.ref_name }}
+            PYRSIA_VERSION=${{ env.PKG_VERSION }}+${{ github.run_number }}
+
       - name: Execute Test Cases
         run: |
           cargo test --workspace --verbose --release

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,26 +61,10 @@ jobs:
           .github/workflows/build.sh
           sccache --show-stats
 
-      # Build docker image to use in integration tests
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Build and Push Docker Image for Pyrsia Node
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          push: false
-          file: ./Dockerfile
-          tags: pyrsia/test-node:latest
-          build-args: |
-            GIT_REPO=${{ github.repository }}
-            GIT_COMMIT=${{ github.sha }}
-            GIT_BRANCH=${{ github.ref_name }}
-            PYRSIA_VERSION=${{ env.PKG_VERSION }}+${{ github.run_number }}
-
       - name: Execute Test Cases
         run: |
-          cargo test --workspace --verbose --release
+          cargo test --lib --workspace --verbose --release
+          cargo test --doc --workspace --verbose --release
 
       # Creates installer archive of pyrsia and pyrsia_node
       - id: generate-homebrew-archives
@@ -170,7 +154,8 @@ jobs:
 
       - name: Execute Test Cases
         run: |
-          cargo test --workspace --verbose --release
+          cargo test --lib --workspace --verbose --release
+          cargo test --doc --workspace --verbose --release
 
       # Create installers
       - name: Create MSIs

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,6 +61,20 @@ jobs:
           .github/workflows/build.sh
           sccache --show-stats
 
+      # Build docker image to use in integration tests
+      - name: Build and Push Docker Image for Pyrsia Node
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: false
+          file: ./Dockerfile
+          tags: pyrsia/test-node:latest
+          build-args: |
+            GIT_REPO=${{ github.repository }}
+            GIT_COMMIT=${{ github.sha }}
+            GIT_BRANCH=${{ github.ref_name }}
+            PYRSIA_VERSION=${{ env.PKG_VERSION }}+${{ github.run_number }}
+
       - name: Execute Test Cases
         run: |
           cargo test --workspace --verbose --release

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -299,7 +299,7 @@ jobs:
           context: .
           push: false
           file: ./Dockerfile
-          tags: pyrsia/test-node:latest
+          tags: pyrsia/test_node
           build-args: |
             GIT_REPO=${{ github.repository }}
             GIT_COMMIT=${{ github.sha }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -304,6 +304,23 @@ jobs:
         with:
           packages: cargo-tarpaulin
 
+      # Build docker image to use in integration tests
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and Push Docker Image for Pyrsia Node
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: false
+          file: ./Dockerfile
+          tags: pyrsia/test-node:latest
+          build-args: |
+            GIT_REPO=${{ github.repository }}
+            GIT_COMMIT=${{ github.sha }}
+            GIT_BRANCH=${{ github.ref_name }}
+            PYRSIA_VERSION=${{ env.PKG_VERSION }}+${{ github.run_number }}
+
       - name: Run cargo-tarpaulin
         run: |
           cargo tarpaulin --workspace --lib --bins --tests --benches --out Lcov --output-dir ./coverage

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,7 +176,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time",
+ "time 0.3.17",
 ]
 
 [[package]]
@@ -183,7 +192,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time",
+ "time 0.3.17",
 ]
 
 [[package]]
@@ -226,6 +235,20 @@ name = "asn1_der"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e22d1f4b888c298a027c99dc9048015fac177587de20fc30232a057dfbe24a21"
+
+[[package]]
+name = "assert_cmd"
+version = "2.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9834fcc22e0874394a010230586367d4a3e9f11b560f469262678547e1d2575e"
+dependencies = [
+ "bstr 1.3.0",
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
 
 [[package]]
 name = "async-io"
@@ -468,6 +491,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
+name = "bollard-stubs"
+version = "1.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2f2e73fffe9455141e170fb9c1feb0ac521ec7e7dcd47a7cab72a658490fb8"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_with",
+]
+
+[[package]]
 name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -481,6 +515,18 @@ checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
  "lazy_static",
  "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
+name = "bstr"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ffdb39cb703212f3c11973452c2861b972f757b021158f3516ba10f2fa8b2c1"
+dependencies = [
+ "memchr",
+ "once_cell",
  "regex-automata",
  "serde",
 ]
@@ -573,6 +619,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "time 0.1.45",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
 name = "cipher"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -625,6 +687,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
 ]
 
 [[package]]
@@ -844,7 +916,7 @@ version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
 dependencies = [
- "bstr",
+ "bstr 0.2.17",
  "csv-core",
  "itoa 0.4.8",
  "ryu",
@@ -927,13 +999,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "cxx"
+version = "1.0.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86d3488e7665a7a483b57e25bdd90d0aeb2bc7608c8d0346acf2ad3f1caf1d62"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fcaf066a053a41a81dfb14d57d99738b767febb8b735c3016e469fac5da690"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2ef98b8b717a829ca5603af80e1f9e2e48013ab227b68ef37872ef84ee479bf"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "086c685979a698443656e5cf7856c95c642295a38599f12fb1ff76fb28d19892"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
 name = "darling"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.14.2",
+ "darling_macro 0.14.2",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
 ]
 
 [[package]]
@@ -952,11 +1092,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core 0.13.4",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
 dependencies = [
- "darling_core",
+ "darling_core 0.14.2",
  "quote",
  "syn",
 ]
@@ -1085,7 +1236,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f91d4cfa921f1c05904dc3c57b4a32c38aed3340cce209f3a6fd1478babafc4"
 dependencies = [
- "darling",
+ "darling 0.14.2",
  "proc-macro2",
  "quote",
  "syn",
@@ -1097,7 +1248,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
 dependencies = [
- "darling",
+ "darling 0.14.2",
  "proc-macro2",
  "quote",
  "syn",
@@ -1135,6 +1286,12 @@ dependencies = [
  "rustc_version",
  "syn",
 ]
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
@@ -1195,6 +1352,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dtoa"
@@ -1434,6 +1597,15 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "fnv"
@@ -1859,7 +2031,7 @@ version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f25cfb6def593d43fae1ead24861f217e93bc70768a45cc149a69b5f049df4"
 dependencies = [
- "bstr",
+ "bstr 0.2.17",
  "bytes",
  "crossbeam-channel",
  "form_urlencoded",
@@ -1925,6 +2097,30 @@ dependencies = [
  "rustls 0.20.7",
  "tokio",
  "tokio-rustls",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
 ]
 
 [[package]]
@@ -2617,6 +2813,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "link-cplusplus"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2935,6 +3140,12 @@ checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "ntapi"
@@ -3306,6 +3517,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "predicates"
+version = "2.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
+dependencies = [
+ "difflib",
+ "float-cmp",
+ "itertools",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f883590242d3c6fc5bf50299011695fa6590c2c70eac95ee1bdb9a733ad1a2"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54ff541861505aabf6ea722d2131ee980b8276e10a1297b94e896dd8b621850d"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "pretty_env_logger"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3522,7 +3763,7 @@ dependencies = [
  "tempfile",
  "test-log",
  "thiserror",
- "time",
+ "time 0.3.17",
  "tokio",
  "tokio-stream",
  "tokio-test",
@@ -3568,15 +3809,18 @@ name = "pyrsia_cli"
 version = "0.2.5"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "clap",
  "confy",
  "const_format",
  "futures",
  "lazy_static",
+ "predicates",
  "pyrsia",
  "reqwest",
  "serde",
  "serde_json",
+ "testcontainers",
  "tokio",
  "vergen",
  "walkdir",
@@ -3744,7 +3988,7 @@ checksum = "6413f3de1edee53342e6138e75b56d32e7bc6e332b3bd62d497b1929d4cfbcdd"
 dependencies = [
  "pem",
  "ring",
- "time",
+ "time 0.3.17",
  "x509-parser 0.13.2",
  "yasna",
 ]
@@ -3757,7 +4001,7 @@ checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
 dependencies = [
  "pem",
  "ring",
- "time",
+ "time 0.3.17",
  "yasna",
 ]
 
@@ -4074,6 +4318,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "scratch"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
+
+[[package]]
 name = "sct"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4193,6 +4443,28 @@ dependencies = [
  "itoa 1.0.5",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
+dependencies = [
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
+dependencies = [
+ "darling 0.13.4",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4515,6 +4787,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95059e91184749cb66be6dc994f67f182b6d897cb3df74a5bf66b5e709295fd8"
+
+[[package]]
 name = "test-log"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4523,6 +4801,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "testcontainers"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e2b1567ca8a2b819ea7b28c92be35d9f76fb9edb214321dcc86eb96023d1f87"
+dependencies = [
+ "bollard-stubs",
+ "futures",
+ "hex",
+ "hmac 0.12.1",
+ "log",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "sha2 0.10.6",
 ]
 
 [[package]]
@@ -4543,6 +4838,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
 ]
 
 [[package]]
@@ -4880,6 +5186,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4960,7 +5272,7 @@ dependencies = [
  "rustversion",
  "sysinfo",
  "thiserror",
- "time",
+ "time 0.3.17",
 ]
 
 [[package]]
@@ -4974,6 +5286,15 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "waitgroup"
@@ -5045,6 +5366,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -5198,7 +5525,7 @@ dependencies = [
  "sha2 0.10.6",
  "stun",
  "thiserror",
- "time",
+ "time 0.3.17",
  "tokio",
  "turn",
  "url",
@@ -5597,7 +5924,7 @@ dependencies = [
  "ring",
  "rusticata-macros",
  "thiserror",
- "time",
+ "time 0.3.17",
 ]
 
 [[package]]
@@ -5615,7 +5942,7 @@ dependencies = [
  "oid-registry 0.6.1",
  "rusticata-macros",
  "thiserror",
- "time",
+ "time 0.3.17",
 ]
 
 [[package]]
@@ -5638,7 +5965,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aed2e7a52e3744ab4d0c05c20aa065258e84c49fd4226f5191b2ed29712710b4"
 dependencies = [
- "time",
+ "time 0.3.17",
 ]
 
 [[package]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ ENV PYRSIA_BLOCKCHAIN_PATH=pyrsia/blockchain
 RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -; \
     apt-get install -y -q nodejs; \
     npm i -g toml-cli; \
-    rustup default $(cat Cargo.toml | toml | jq -r 'try(.package."rust-version") // "stable"') 
+    rustup default $(cat Cargo.toml | toml | jq -r 'try(.package."rust-version") // "stable"')
 RUN --mount=target=/src \
     --mount=type=cache,target=/target \
     --mount=type=cache,target=/usr/local/cargo/git/db \
@@ -53,6 +53,9 @@ COPY --from=dbuild /out/pyrsia_node /usr/bin/
 
 COPY installers/docker/node-entrypoint.sh /tmp/entrypoint.sh
 RUN chmod 755 /tmp/entrypoint.sh; mkdir -p /usr/local/var/pyrsia
+
+COPY installers/docker/test-listen-only-node-entrypoint.sh /tmp/test-listen-only-node-entrypoint.sh
+RUN chmod 755 /tmp/test-listen-only-node-entrypoint.sh;
 
 WORKDIR /usr/local/var
 

--- a/installers/docker/test-listen-only-node-entrypoint.sh
+++ b/installers/docker/test-listen-only-node-entrypoint.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+/usr/bin/pyrsia_node --listen-only -p 7888 --init-blockchain --host 0.0.0.0

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -27,7 +27,7 @@ fi
 cargo install cargo-audit || exit_on_error "Could not install cargo audit."
 cargo audit --ignore RUSTSEC-2022-0040 --ignore RUSTSEC-2020-0071 || exit_on_error "Cargo audit failed."
 cargo clippy || exit_on_error "Cargo clippy failed."
-#cargo fmt --check || exit_on_error "Cargo format failed."
+cargo fmt --check || exit_on_error "Cargo format failed."
 if [[ "$1" == "ignore-it" || $2 == "ignore-it" ]] ; then
     printf "Ignore integration tests.\n"
     cargo test --lib || exit_on_error "Cargo lib test failed."

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -7,16 +7,37 @@ exit_on_error() {
     fi
 }
 
+rmi_and_exit_on_error() {
+  docker rmi pyrsia/test_node:latest
+
+  exit_msg=$1
+  if [[ "$exit_msg" != "" ]]; then
+      >&2 printf "$exit_msg\n"
+      exit 1
+  fi
+}
+
 printf "Running Pyrsia pre-commit validation.\n"
 printf "This might take sometime, please do not interrupt if the screen is blank.\n"
-if [[ "$1" == "clean" ]] ; then
+if [[ "$1" == "clean" || $2 == "clean" ]] ; then
 	printf "Cleaning old build artifacts.\n"
 	cargo clean
 fi
 
 cargo install cargo-audit || exit_on_error "Could not install cargo audit."
-cargo audit --ignore RUSTSEC-2022-0040 || exit_on_error "Cargo audit failed."
+cargo audit --ignore RUSTSEC-2022-0040 --ignore RUSTSEC-2020-0071 || exit_on_error "Cargo audit failed."
 cargo clippy || exit_on_error "Cargo clippy failed."
-cargo fmt --check || exit_on_error "Cargo format failed."
-cargo test --workspace || exit_on_error "Cargo test failed."
+#cargo fmt --check || exit_on_error "Cargo format failed."
+if [[ "$1" == "ignore-it" || $2 == "ignore-it" ]] ; then
+    printf "Ignore integration tests.\n"
+    cargo test --lib || exit_on_error "Cargo lib test failed."
+    cargo test --doc || exit_on_error "Cargo doc test failed."
+  else
+    printf "Run all tests.\n"
+    docker rmi pyrsia/test_node:latest
+    DOCKER_BUILDKIT=1 docker build -t=pyrsia/test_node .
+    cargo test --workspace || rmi_and_exit_on_error "Cargo test failed."
+    docker rmi pyrsia/test_node:latest
+fi
+
 cargo build --workspace --all-targets

--- a/pyrsia_cli/Cargo.toml
+++ b/pyrsia_cli/Cargo.toml
@@ -27,3 +27,8 @@ path = "src/main.rs"
 anyhow = "1.0"
 vergen = "7.5.0"
 
+[dev-dependencies]
+testcontainers = "0.14.0"
+assert_cmd = "2.0.8"
+predicates = "2.1.5"
+

--- a/pyrsia_cli/tests/inspect_log_artifacts.rs
+++ b/pyrsia_cli/tests/inspect_log_artifacts.rs
@@ -1,0 +1,65 @@
+use std::{thread, time};
+use testcontainers::images;
+use assert_cmd::Command;
+use predicates::prelude::predicate;
+use reqwest::StatusCode;
+use testcontainers::clients::Cli;
+use testcontainers::core::WaitFor;
+
+const NAME: &str = "pyrsia/test_node";
+const TAG: &str = "latest";
+const DEF_PORT: u16 = 7888;
+const DEF_TIMEOUT: u64 = 1500;
+
+#[test]
+fn run_pyrsia_node_with_status_checks() {
+    let docker = Cli::default();
+    let generic = images::generic::GenericImage::new(NAME, TAG)
+        .with_entrypoint("/tmp/test-listen-only-node-entrypoint.sh")
+        .with_exposed_port(DEF_PORT)
+        .with_wait_for(WaitFor::millis(DEF_TIMEOUT));
+
+    let node = docker.run(generic);
+    let port = node.get_host_port_ipv4(DEF_PORT);
+
+    let mut res = reqwest::blocking::get(&format!("http://127.0.0.1:{}/status", port));
+
+    let mut count: u8 = 0;
+    while res.is_err() && count < 25 {
+        thread::sleep(time::Duration::from_micros(DEF_TIMEOUT));
+
+        res = reqwest::blocking::get(&format!("http://0.0.0.0:{}/status", port));
+        count += 1;
+    }
+
+    assert_eq!(res.unwrap().status(), StatusCode::OK);
+
+    let client = reqwest::blocking::Client::new();
+    let resp = client.post(&format!("http://0.0.0.0:{}/inspect/docker", port))
+        .body("{\"image\": \"alpine:3.16\"}")
+        .send()
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    Command::cargo_bin("pyrsia").unwrap()
+        .arg("-c")
+        .arg("-e")
+        .arg("-H")
+        .arg("0.0.0.0")
+        .arg("-p")
+        .arg(port.to_string())
+        .assert()
+        .stdout(predicate::str::diff("Node configuration saved !!\n"));
+
+    let res = Command::cargo_bin("pyrsia").unwrap()
+        .arg("inspect-log")
+        .arg("docker")
+        .arg("--image")
+        .arg("alpine:3.16")
+        .assert()
+        .stdout(predicate::str::diff("[]\n"));
+
+    println!("Pyrsia: {}",
+             String::from_utf8_lossy(res.get_output().stdout.as_slice())
+    );
+}

--- a/pyrsia_cli/tests/inspect_log_artifacts.rs
+++ b/pyrsia_cli/tests/inspect_log_artifacts.rs
@@ -1,10 +1,26 @@
-use std::{thread, time};
-use testcontainers::images;
+/*
+   Copyright 2021 JFrog Ltd
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 use assert_cmd::Command;
 use predicates::prelude::predicate;
 use reqwest::StatusCode;
+use std::{thread, time};
 use testcontainers::clients::Cli;
 use testcontainers::core::WaitFor;
+use testcontainers::images;
 
 const NAME: &str = "pyrsia/test_node";
 const TAG: &str = "latest";
@@ -35,13 +51,15 @@ fn run_pyrsia_node_with_status_checks() {
     assert_eq!(res.unwrap().status(), StatusCode::OK);
 
     let client = reqwest::blocking::Client::new();
-    let resp = client.post(&format!("http://0.0.0.0:{}/inspect/docker", port))
+    let resp = client
+        .post(&format!("http://0.0.0.0:{}/inspect/docker", port))
         .body("{\"image\": \"alpine:3.16\"}")
         .send()
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
 
-    Command::cargo_bin("pyrsia").unwrap()
+    Command::cargo_bin("pyrsia")
+        .unwrap()
         .arg("-c")
         .arg("-e")
         .arg("-H")
@@ -51,7 +69,8 @@ fn run_pyrsia_node_with_status_checks() {
         .assert()
         .stdout(predicate::str::diff("Node configuration saved !!\n"));
 
-    let res = Command::cargo_bin("pyrsia").unwrap()
+    let res = Command::cargo_bin("pyrsia")
+        .unwrap()
         .arg("inspect-log")
         .arg("docker")
         .arg("--image")
@@ -59,7 +78,8 @@ fn run_pyrsia_node_with_status_checks() {
         .assert()
         .stdout(predicate::str::diff("[]\n"));
 
-    println!("Pyrsia: {}",
-             String::from_utf8_lossy(res.get_output().stdout.as_slice())
+    println!(
+        "Pyrsia: {}",
+        String::from_utf8_lossy(res.get_output().stdout.as_slice())
     );
 }


### PR DESCRIPTION
Referred to #1454

`pre-commit.sh` builds the `pyrsia/test_node` image, runs tests and removes the image after tests.

The flag `ignore-it` allows ignoring integration tests.

Evolution:
 - Create Dockerfile for tests purposes as test resource.
 - Prepare SQLite db file and copy it into container to test node responses (maybe, is there a better idea?)
 - To test p2p communications between nodes, we should have a test discovery service. Do we have a test discovery service?

